### PR TITLE
fix: check for arches dir and set ARCHES_ROOT

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,21 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base:coral
+ifeq ($(wildcard /../arches),)
+	ARCHES_ROOT=$(realpath ../arches)
+else
+	
+	ARCHES_ROOT=
+endif
+ifneq ($(ARCHES_ROOT),)
+  DOCKER_COMPOSE_FILES = -f docker/docker-compose.yml -f docker/docker-compose.override.yml
+else
+  DOCKER_COMPOSE_FILES = -f docker/docker-compose.yml
+endif
+APPS_VOLUME_MOUNTS=$(shell if [ -d "apps" ]; then for dir in apps/*; do if [ -d "$$dir" ]; then echo "-v $$(pwd)/$$dir:/web_root/$$dir "; fi; done; fi)
+ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-7.6
 ARCHES_PROJECT_ROOT = $(shell pwd)/
-DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker-compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
+DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
 CMD ?=
 
 create: docker

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+services:
+  arches:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+  arches_api:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+  arches_worker:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,6 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
@@ -105,8 +103,6 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
@@ -160,8 +156,6 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh


### PR DESCRIPTION
## Description
This checks to see if an arches repo lives in the parent directory. 
If it does it sets ARCHES_ROOT to that directory, if not it sets it as an empty string

An additional docker-compose file has then been created which contains the additional volume mounts for ARCHES_ROOT. If the variable has been set, these are applied with the original in the volume mounts.

## Test
Run a copy of arches without the base arches. 
The instance should start without an ARCHES_ROOT error.
Add the arches root dir into the parent directory, add a log statement somewhere that will run
Restart the containers and see if the log statement is visible

### Additional
I believe we may be able to adjust this to automatically build mounts for any apps that we want to install. If we set up an app dir in the parent directory we could build an additional docker compose to create the mount paths