### PR TITLE
fix: added always param to x-content header

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -2,7 +2,7 @@ server {
     listen       8080;     
     server_name  localhost;
 
-    add_header X-Content-Type-Options "nosniff";
+    add_header X-Content-Type-Options "nosniff" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
                                                       
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
Changes: 

Added always parameter to X-Content-Type-Options header in default.conf

Reason: 

This fixes the header not appearing if the response code is 404 for example. The X-Content-Type-Options header will always be included in the request  