### PR TITLE
Fix/coral v8 docker fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN . ../ENV/bin/activate \
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
-RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json
+# RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json
+RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN . ../ENV/bin/activate \
 COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
-    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi)
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi) \
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi)
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 RUN ../entrypoint.sh install_npm_components
+RUN . ../ENV/bin/activate && python manage.py
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
-RUN ../entrypoint.sh install_yarn_components
+RUN ../entrypoint.sh install_npm_components
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@ COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then pip install -e ${WEB_ROOT}/${ARCHES_PROJECT}; fi) \
-    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt; fi)
+    && pip install -e ${WEB_ROOT}/arches \
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt; fi) # ensure that we have the arches from _inside_ the container
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 RUN ../entrypoint.sh install_npm_components
-RUN . ../ENV/bin/activate && python manage.py
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY docker/entrypoint.sh ${WEB_ROOT}/
-RUN apt-get update && apt-get -y install python3-libxml2 git
+RUN apt-get update && apt-get -y install python3-libxml2 git postgresql-client
 RUN apt-get -y install build-essential python3-dev 
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \
@@ -21,12 +21,12 @@ RUN . ../ENV/bin/activate \
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
-RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack && echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
-RUN ../entrypoint.sh install_yarn_components
+RUN ../entrypoint.sh install_npm_components
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN . ../ENV/bin/activate \
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
-RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && ch
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
 # RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json
-RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ RUN . ../ENV/bin/activate \
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
-# RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json
 RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,12 +16,14 @@ RUN . ../ENV/bin/activate \
 COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then pip install -e ${WEB_ROOT}/${ARCHES_PROJECT}; fi) \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt; fi)
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack && echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+RUN echo "{}" > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
-ARG ARCHES_BASE=flaxandteal/arches_base
+ARG ARCHES_BASE=ghcr.io/flaxandteal/arches-base:docker-8.1
 FROM $ARCHES_BASE
 
 RUN useradd arches
 RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
-COPY docker/entrypoint.sh ${WEB_ROOT}/
+COPY ${ARCHES_PROJECT}/docker/entrypoint.sh ${WEB_ROOT}/
 RUN apt-get update && apt-get -y install python3-libxml2 git
-RUN apt-get -y install build-essential python3-dev 
+RUN apt-get -y install build-essential python3-dev
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \
     && pip install starlette-graphene3 \
     && pip install "lxml" starlette-context "google-auth<2.23" django-authorization casbin-django-orm-adapter \
     && pip install django-debug-toolbar django-debug-toolbar-force # only needed in debug
-COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
+COPY ${ARCHES_PROJECT}/ ${WEB_ROOT}/${ARCHES_PROJECT}/
 ARG EDITABLE_BASE=false
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
@@ -24,15 +24,27 @@ RUN . ../ENV/bin/activate \
         pip install ${WEB_ROOT}/arches; \
     fi
 
+ARG USE_LOCAL_APPS=false
+COPY arches_app[s]/ ${WEB_ROOT}/arches_apps/
+RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
+        . ../ENV/bin/activate && \
+        for d in ${WEB_ROOT}/arches_apps/*/; do \
+            pip install --no-deps -e "$d" || true; \
+        done; \
+    fi
+
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
-COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
+COPY ${ARCHES_PROJECT}/docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
 RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 RUN ../entrypoint.sh install_npm_components
+RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
+        ../entrypoint.sh run_npm_build_development; \
+    fi
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
 USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY ${ARCHES_PROJECT}/docker/entrypoint.sh ${WEB_ROOT}/
 RUN apt-get update && apt-get -y install --no-install-recommends \
-    python3-libxml2 git build-essential python3-dev \
+    python3-libxml2 git build-essential python3-dev xmlsec1 \
     && rm -rf /var/lib/apt/lists/*
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,8 @@ COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi) \
-    && pip install -e ${WEB_ROOT}/arches \
-    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi)
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
+    && pip install -e ${WEB_ROOT}/arches
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,4 +52,4 @@ RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
     fi
 ENTRYPOINT ../entrypoint.sh
 CMD run_arches
-USER 1000
+USER arches

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,22 +6,26 @@ RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY ${ARCHES_PROJECT}/docker/entrypoint.sh ${WEB_ROOT}/
-RUN apt-get update && apt-get -y install python3-libxml2 git
-RUN apt-get -y install build-essential python3-dev
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    python3-libxml2 git build-essential python3-dev \
+    && rm -rf /var/lib/apt/lists/*
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \
-    && pip install starlette-graphene3 \
-    && pip install "lxml" starlette-context "google-auth<2.23" django-authorization casbin-django-orm-adapter \
-    && pip install django-debug-toolbar django-debug-toolbar-force # only needed in debug
+    && pip install starlette-graphene3 "lxml" starlette-context "google-auth<2.23" \
+       django-authorization casbin-django-orm-adapter \
+       django-debug-toolbar django-debug-toolbar-force
 COPY ${ARCHES_PROJECT}/ ${WEB_ROOT}/${ARCHES_PROJECT}/
 ARG EDITABLE_BASE=false
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
-    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
     && if [ "$EDITABLE_BASE" = "True" ]; then \
         pip install -e ${WEB_ROOT}/arches; \
     else \
         pip install ${WEB_ROOT}/arches; \
+    fi \
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
+    && if [ "$EDITABLE_BASE" = "True" ]; then \
+        pip install -e ${WEB_ROOT}/arches; \
     fi
 
 ARG USE_LOCAL_APPS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi) \
+    && pip install -e ${WEB_ROOT}/arches \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi)
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,15 @@ RUN . ../ENV/bin/activate \
     && pip install "lxml" starlette-context "google-auth<2.23" django-authorization casbin-django-orm-adapter \
     && pip install django-debug-toolbar django-debug-toolbar-force # only needed in debug
 COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
+ARG EDITABLE_BASE=false
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
-    && pip install ${WEB_ROOT}/arches
+    && if [ "$EDITABLE_BASE" = "true" ]; then \
+        pip install -e ${WEB_ROOT}/arches; \
+    else \
+        pip install ${WEB_ROOT}/arches; \
+    fi
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM $ARCHES_BASE
 
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
-COPY ${ARCHES_PROJECT}/docker/entrypoint.sh ${WEB_ROOT}/
+COPY docker/entrypoint.sh ${WEB_ROOT}/
 RUN chgrp 1000 ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 RUN apt-get update && apt-get -y install --no-install-recommends \
     python3-libxml2 git build-essential python3-dev xmlsec1 \
@@ -13,7 +13,7 @@ RUN . ../ENV/bin/activate \
     && pip install starlette-graphene3 "lxml" starlette-context "google-auth<2.23" \
        django-authorization casbin-django-orm-adapter \
        django-debug-toolbar django-debug-toolbar-force
-COPY ${ARCHES_PROJECT}/ ${WEB_ROOT}/${ARCHES_PROJECT}/
+COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 ARG EDITABLE_BASE=false
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
@@ -22,6 +22,7 @@ RUN . ../ENV/bin/activate \
     else \
         pip install ${WEB_ROOT}/arches; \
     fi \
+    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt; fi) \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
     && if [ "$EDITABLE_BASE" = "True" ]; then \
         pip install -e ${WEB_ROOT}/arches; \
@@ -38,7 +39,7 @@ RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R 1000 ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
-COPY ${ARCHES_PROJECT}/docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
+COPY docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
 RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi) \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
-    && pip install -e ${WEB_ROOT}/arches
+    && pip install ${WEB_ROOT}/arches
 
 RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY docker/entrypoint.sh ${WEB_ROOT}/
-RUN apt-get update && apt-get -y install python3-libxml2 git postgresql-client
+RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN apt-get -y install build-essential python3-dev 
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \
@@ -16,7 +16,6 @@ RUN . ../ENV/bin/activate \
 COPY . ${WEB_ROOT}/${ARCHES_PROJECT}/
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
-    && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt ]; then pip install -r ${WEB_ROOT}/${ARCHES_PROJECT}/requirements.txt --no-binary :all:; fi) \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
     && pip install ${WEB_ROOT}/arches
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' 
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
 RUN mkdir -p /static_root && chown -R arches /static_root
+RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration && chown -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 RUN ../entrypoint.sh install_npm_components
 RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ARG EDITABLE_BASE=false
 RUN . ../ENV/bin/activate \
     && pip install cachetools websockets pika "protobuf>4.21,<5.0" \
     && (if [ -f ${WEB_ROOT}/${ARCHES_PROJECT}/pyproject.toml ]; then (cd ${WEB_ROOT}/${ARCHES_PROJECT} && pip install -e .); fi) \
-    && if [ "$EDITABLE_BASE" = "true" ]; then \
+    && if [ "$EDITABLE_BASE" = "True" ]; then \
         pip install -e ${WEB_ROOT}/arches; \
     else \
         pip install ${WEB_ROOT}/arches; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 ARG ARCHES_BASE=ghcr.io/flaxandteal/arches-base:docker-8.1.0-release
 FROM $ARCHES_BASE
 
-RUN useradd arches
-RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY ${ARCHES_PROJECT}/docker/entrypoint.sh ${WEB_ROOT}/
+RUN chgrp 1000 ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 RUN apt-get update && apt-get -y install --no-install-recommends \
     python3-libxml2 git build-essential python3-dev xmlsec1 \
     && rm -rf /var/lib/apt/lists/*
@@ -37,19 +36,19 @@ RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
         done; \
     fi
 
-RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
+RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chgrp -R 1000 ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles && chmod -R g+rw ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/uploadedfiles
 
 COPY ${ARCHES_PROJECT}/docker/settings_docker.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py
 RUN echo '{"status": "", "assets": {}, "chunks": {}, "publicPath": "/static/"}' > ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
-RUN mkdir -p /static_root && chown -R arches /static_root
-RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration && chown -R arches ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration
+RUN mkdir -p /static_root && chown -R 1000 /static_root
+RUN mkdir -p ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration && chown -R 1000 ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 RUN ../entrypoint.sh install_npm_components
 RUN if [ "$USE_LOCAL_APPS" = "true" ]; then \
         ../entrypoint.sh run_npm_build_development; \
     fi
-ENTRYPOINT ../entrypoint.sh
-CMD run_arches
-USER arches
+ENTRYPOINT ["../entrypoint.sh"]
+CMD ["run_arches"]
+USER 1000

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN chgrp arches ../entrypoint.sh && chmod g+rx ../entrypoint.sh
 ARG ARCHES_PROJECT
 ENV ARCHES_PROJECT $ARCHES_PROJECT
 COPY docker/entrypoint.sh ${WEB_ROOT}/
-RUN apt-get update && apt-get -y install python3-libxml2 git
+RUN apt-get update && apt-get -y install python3-libxml2 git postgresql-client
 RUN apt-get -y install build-essential python3-dev 
 RUN . ../ENV/bin/activate \
     && pip install --upgrade pip setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ARCHES_BASE=ghcr.io/flaxandteal/arches-base:docker-8.1
+ARG ARCHES_BASE=ghcr.io/flaxandteal/arches-base:docker-8.1.0-release
 FROM $ARCHES_BASE
 
 RUN useradd arches

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,126 @@
+FROM ubuntu:24.04 AS base
+USER root
+
+## Setting default environment variables
+ENV WEB_ROOT=/web_root
+# Root project folder
+ENV ARCHES_ROOT=${WEB_ROOT}/arches
+ENV WHEELS=/wheels
+ENV PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y make software-properties-common
+
+FROM base AS wheelbuilder
+
+WORKDIR ${WHEELS}
+
+# Install packages required to build the python libs, then remove them
+RUN set -ex \
+    && BUILD_DEPS=" \
+        build-essential \
+        libxml2-dev \
+        libproj-dev \
+        libjson-c-dev \
+        xsltproc \
+        docbook-xsl \
+        docbook-mathml \
+        libgdal-dev \
+        libpq-dev \
+        python3.12 \
+        python3.12-dev \
+        curl \
+        libldap2-dev libsasl2-dev ldap-utils \
+        dos2unix \
+        " \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends $BUILD_DEPS
+
+RUN apt-get install -y python3-pip
+
+RUN pip wheel --no-cache-dir gunicorn \
+    && pip wheel --no-cache-dir django-auth-ldap \
+    && pip wheel --no-cache-dir psycopg2==2.9.10
+
+# Add Docker-related files
+COPY docker/entrypoint.sh ${WHEELS}/entrypoint.sh
+RUN chmod -R 700 ${WHEELS} &&\
+  dos2unix ${WHEELS}/*.sh
+
+FROM base 
+
+# Get the pre-built python wheels from the build environment
+RUN mkdir ${WEB_ROOT}
+
+COPY --from=wheelbuilder ${WHEELS} /wheels
+
+# Install packages required to run Arches
+# Note that the ubuntu/debian package for libgdal1-dev pulls in libgdal1i, which is built
+# with everything enabled, and so, it has a huge amount of dependancies (everything that GDAL
+# support, directly and indirectly pulling in mysql-common, odbc, jp2, perl! ... )
+# a minimised build of GDAL could remove several hundred MB from the container layer.
+RUN set -ex \
+    && RUN_DEPS=" \
+        libgdal-dev \
+        libpq-dev \
+        python3-venv \
+        postgresql-client-14 \
+        python3.12 \
+        python3-pip \
+        python3.12-venv \
+    " \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && NODE_MAJOR=20 \
+    && (echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" > /etc/apt/sources.list.d/nodesource.list) \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /etc/apt/keyrings/postgresql.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/postgresql.gpg] http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -sc)-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update -y \
+    && apt-get install -y --no-install-recommends $RUN_DEPS \
+    && apt-get install -y nodejs
+
+# Install npm components
+COPY ./package.json ${ARCHES_ROOT}/package.json
+WORKDIR ${ARCHES_ROOT}
+RUN mkdir -p ${ARCHES_ROOT}/node_modules
+RUN apt-get install -y git
+RUN npm install
+
+## Install virtualenv
+WORKDIR ${WEB_ROOT}
+
+RUN mv ${WHEELS}/entrypoint.sh entrypoint.sh
+
+RUN python3.12 -m venv ENV \
+    && . ENV/bin/activate \
+    && pip install --upgrade pip \
+    && pip install wheel setuptools requests \
+    && pip install -f ${WHEELS} django-auth-ldap \
+    && pip install -f ${WHEELS} gunicorn \
+    && pip install -f ${WHEELS} psycopg2==2.9.10 \
+    && rm -rf ${WHEELS} \
+    && rm -rf /root/.cache/pip/*
+
+# Install the Arches application
+# FIXME: ADD from github repository instead?
+COPY . ${ARCHES_ROOT}
+
+# From here, run commands from ARCHES_ROOT
+WORKDIR ${ARCHES_ROOT}
+
+RUN . ../ENV/bin/activate \
+    && pip install -e . --group dev
+
+# Set default workdir
+WORKDIR ${ARCHES_ROOT}
+
+COPY docker/gunicorn_config.py ${ARCHES_ROOT}/gunicorn_config.py
+COPY docker/settings_local.py ${ARCHES_ROOT}/arches/settings_local.py
+
+# Set entrypoint
+ENTRYPOINT ["../entrypoint.sh"]
+CMD ["run_arches"]
+
+# Expose port 8000
+EXPOSE 8000

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -69,6 +69,7 @@ python manage.py es index_database\
 ";
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
+RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -51,15 +51,15 @@ ENV DJANGO_DEBUG=False \
     DJANGO_SETTINGS_MODULE=${ARCHES_PROJECT}.settings
 WORKDIR ${WEB_ROOT}/${ARCHES_PROJECT}
 
-RUN ${WEB_ROOT}/entrypoint.sh init_yarn_components
+RUN ${WEB_ROOT}/entrypoint.sh init_npm_components
 
 # FIXME: To be replaced once per-project settings working
 RUN (echo "\nSTATIC_ROOT='${STATIC_ROOT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT 
 RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPORT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPACE_FOR_DATA_EXPORT" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 
-RUN (cd $WEB_ROOT/arches/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT/media/node_modules yarn install)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules yarn install -D)
+RUN (cd $WEB_ROOT/arches/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT/media/node_modules npm install)
+RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
 RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN /bin/bash -c ". ../ENV/bin/activate;\
 python manage.py createcachetable;\
@@ -69,7 +69,7 @@ python manage.py es index_database\
 ";
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
-RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_yarn_build_${ARCHES_ENVIRONMENT}
+RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine
 ARG WEB_ROOT=/web_root

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -77,7 +77,9 @@ ARG STATIC_ROOT=/static_root
 ARG ARCHES_PROJECT
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json /usr/share/nginx/webpack-stats.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack-stats.json /usr/share/nginx/webpack-stats.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json /usr/share/nginx/.frontend-configuration-settings.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json /usr/share/nginx/.tsconfig-paths.json
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static
 #RUN mv /usr/share/nginx/html/static/* /usr/share/nginx/html
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -77,7 +77,7 @@ ARG STATIC_ROOT=/static_root
 ARG ARCHES_PROJECT
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json /usr/share/nginx/webpack-stats.json
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/node_modules/js-cookie/src/js.cookie.js /usr/share/nginx/html/js/js-cookie.js
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static
 #RUN mv /usr/share/nginx/html/static/* /usr/share/nginx/html

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -59,7 +59,7 @@ RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPOR
 RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPACE_FOR_DATA_EXPORT" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 
 RUN (cd $WEB_ROOT/arches/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT/media/node_modules npm install)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D && ls ./media/node_modules)
+RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
 RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN /bin/bash -c ". ../ENV/bin/activate;\
 python manage.py createcachetable;\

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -78,7 +78,6 @@ ARG ARCHES_PROJECT
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack-stats.json /usr/share/nginx/webpack-stats.json
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/node_modules/js-cookie/src/js.cookie.js /usr/share/nginx/html/js/js-cookie.js
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static
 #RUN mv /usr/share/nginx/html/static/* /usr/share/nginx/html
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -77,7 +77,7 @@ ARG STATIC_ROOT=/static_root
 ARG ARCHES_PROJECT
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack-stats.json /usr/share/nginx/webpack-stats.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json /usr/share/nginx/.frontend-configuration-settings.json
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json /usr/share/nginx/.tsconfig-paths.json
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN /bin/bash -c ". ../ENV/bin/activate;\
 python manage.py createcachetable;\
 python manage.py load_ontology -s ${ARCHES_PROJECT}/pkg/ontologies;\
-python manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg/ -y --no-business_data;\
+echo 'Need to replace: python manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg/ -y --no-business_data';\
 python manage.py es index_database\
 ";
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -59,7 +59,7 @@ RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPOR
 RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPACE_FOR_DATA_EXPORT" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 
 RUN (cd $WEB_ROOT/arches/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT/media/node_modules npm install)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
+RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D && ls ./media/node_modules)
 RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN /bin/bash -c ". ../ENV/bin/activate;\
 python manage.py createcachetable;\

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -58,8 +58,8 @@ RUN (echo "\nSTATIC_ROOT='${STATIC_ROOT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${AR
 RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPORT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPACE_FOR_DATA_EXPORT" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 
-RUN (cd $WEB_ROOT/arches/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT/media/node_modules npm install)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
+RUN (cd $WEB_ROOT/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/media/node_modules npm install)
+RUN (cd $WEB_ROOT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
 RUN apt-get update && apt-get -y install python3-libxml2 git
 RUN /bin/bash -c ". ../ENV/bin/activate;\
 python manage.py createcachetable;\

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -58,8 +58,8 @@ RUN (echo "\nSTATIC_ROOT='${STATIC_ROOT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${AR
 RUN (echo "\nARCHES_NAMESPACE_FOR_DATA_EXPORT='${ARCHES_NAMESPACE_FOR_DATA_EXPORT}'" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPACE_FOR_DATA_EXPORT" >> ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings_local.py) && echo $STATIC_ROOT
 
-RUN (cd $WEB_ROOT/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/media/node_modules npm install)
-RUN (cd $WEB_ROOT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
+RUN (cd $WEB_ROOT/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/node_modules npm install)
+RUN (cd $WEB_ROOT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./node_modules npm install -D)
 RUN apt-get update && apt-get -y install python3-libxml2 git
 #RUN /bin/bash -c ". ../ENV/bin/activate;\
 #python manage.py createcachetable;\

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get -y install python3-libxml2 git
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
+RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && /bin/bash -c ". ../ENV/bin/activate; python manage.py check"
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -70,7 +70,7 @@ RUN apt-get update && apt-get -y install python3-libxml2 git
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
-RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && /bin/bash -c ". ../ENV/bin/activate; python manage.py check"
+RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && /bin/bash -c ". ../ENV/bin/activate; from arches.app.utils.frontend_configuration_utils import generate_frontend_configuration; generate_frontend_configuration()"
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -61,15 +61,15 @@ RUN (echo "\nPUBLIC_SERVER_ADDRESS='${PUBLIC_SERVER_ADDRESS}' or ARCHES_NAMESPAC
 RUN (cd $WEB_ROOT/arches && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=$WEB_ROOT/$ARCHES_PROJECT/media/node_modules npm install)
 RUN (cd $WEB_ROOT/$ARCHES_PROJECT && NODE_OPTIONS=--max_old_space_size=8192 NODE_PATH=./media/node_modules npm install -D)
 RUN apt-get update && apt-get -y install python3-libxml2 git
-RUN /bin/bash -c ". ../ENV/bin/activate;\
-python manage.py createcachetable;\
-python manage.py load_ontology -s ${ARCHES_PROJECT}/pkg/ontologies;\
-echo 'Need to replace: python manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg/ -y --no-business_data';\
-python manage.py es index_database\
-";
+#RUN /bin/bash -c ". ../ENV/bin/activate;\
+#python manage.py createcachetable;\
+#python manage.py load_ontology -s ${ARCHES_PROJECT}/pkg/ontologies;\
+#echo 'Need to replace: python manage.py packages -o load_package -s ${ARCHES_PROJECT}/pkg/ -y --no-business_data';\
+#python manage.py es index_database\
+#";
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
-RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
-RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
+#RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
+#RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -80,7 +80,7 @@ COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json /usr/share/nginx/.frontend-configuration-settings.json
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json /usr/share/nginx/.tsconfig-paths.json
+#COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json /usr/share/nginx/.tsconfig-paths.json
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static
 #RUN mv /usr/share/nginx/html/static/* /usr/share/nginx/html
 

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -1,6 +1,6 @@
 ARG VERSION
 ARG ARCHES_PROJECT=scarlet
-ARG ARCHES_BASE=flaxandteal/arches_base
+ARG ARCHES_BASE=ghcr.io/flaxandteal/arches-base:docker-8.1.0-release
 ARG ARCHES_DYNAMIC_IMAGE=flaxandteal_${ARCHES_PROJECT}:$VERSION
 ARG WEB_ROOT=/web_root
 ARG ARCHES_ENVIRONMENT=production

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -79,7 +79,8 @@ ARG ARCHES_PROJECT
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
 COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json /usr/share/nginx/.frontend-configuration-settings.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration /usr/share/nginx/frontend_configuration
+#COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json /usr/share/nginx/.frontend-configuration-settings.json
 #COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json /usr/share/nginx/.tsconfig-paths.json
 COPY --from=arches ${STATIC_ROOT} /usr/share/nginx/html/static
 #RUN mv /usr/share/nginx/html/static/* /usr/share/nginx/html

--- a/Dockerfile.static
+++ b/Dockerfile.static
@@ -70,6 +70,7 @@ RUN apt-get update && apt-get -y install python3-libxml2 git
 COPY ./${ARCHES_PROJECT}/settings.py ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/settings.py
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_arches
 #RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && rm -f ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json && /bin/bash -c ". ../ENV/bin/activate; python manage.py check" && cat ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
+RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && /bin/bash -c ". ../ENV/bin/activate; python manage.py shell"
 RUN echo $WEB_ROOT "|" $ARCHES_PROJECT && ${WEB_ROOT}/entrypoint.sh run_npm_build_${ARCHES_ENVIRONMENT}
 
 FROM nginxinc/nginx-unprivileged:1.21.5-alpine

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -12,7 +12,7 @@ ARG STATIC_ROOT=/static_root
 COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 COPY --from=arches_static /usr/share/nginx/.frontend-configuration-settings.json ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
 COPY --from=arches_static /usr/share/nginx/.tsconfig-paths.json ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json
-RUN mkdir -p ${STATIC_ROOT}/CACHE
+# RUN mkdir -p ${STATIC_ROOT}/CACHE
 # COPY --from=arches_static /usr/share/nginx/html/static/CACHE/manifest.json ${STATIC_ROOT}/CACHE/manifest.json
 COPY --from=arches_static /usr/share/nginx/html ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build
 

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -9,7 +9,9 @@ FROM $ARCHES_STATIC_IMAGE as arches_static
 FROM $ARCHES_DYNAMIC_IMAGE as arches
 ARG STATIC_ROOT=/static_root
 
-COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
+COPY --from=arches_static /usr/share/nginx/.frontend-configuration-settings.json ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
+COPY --from=arches_static /usr/share/nginx/.tsconfig-paths.json ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json
 RUN mkdir -p ${STATIC_ROOT}/CACHE
 # COPY --from=arches_static /usr/share/nginx/html/static/CACHE/manifest.json ${STATIC_ROOT}/CACHE/manifest.json
 COPY --from=arches_static /usr/share/nginx/html ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -9,10 +9,6 @@ FROM $ARCHES_STATIC_IMAGE as arches_static
 FROM $ARCHES_DYNAMIC_IMAGE as arches
 ARG STATIC_ROOT=/static_root
 
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
-COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration /usr/share/nginx/frontend_configuration
 COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
 COPY --from=arches_static /usr/share/nginx/frontend_configuration ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration
 # RUN mkdir -p ${STATIC_ROOT}/CACHE

--- a/Dockerfile.static-py
+++ b/Dockerfile.static-py
@@ -9,9 +9,12 @@ FROM $ARCHES_STATIC_IMAGE as arches_static
 FROM $ARCHES_DYNAMIC_IMAGE as arches
 ARG STATIC_ROOT=/static_root
 
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/* /usr/share/nginx/html/
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build/js/* /usr/share/nginx/html/js/
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json /usr/share/nginx/webpack-stats.json
+COPY --from=arches ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration /usr/share/nginx/frontend_configuration
 COPY --from=arches_static /usr/share/nginx/webpack-stats.json ${WEB_ROOT}/${ARCHES_PROJECT}/webpack/webpack-stats.json
-COPY --from=arches_static /usr/share/nginx/.frontend-configuration-settings.json ${WEB_ROOT}/${ARCHES_PROJECT}/.frontend-configuration-settings.json
-COPY --from=arches_static /usr/share/nginx/.tsconfig-paths.json ${WEB_ROOT}/${ARCHES_PROJECT}/.tsconfig-paths.json
+COPY --from=arches_static /usr/share/nginx/frontend_configuration ${WEB_ROOT}/${ARCHES_PROJECT}/frontend_configuration
 # RUN mkdir -p ${STATIC_ROOT}/CACHE
 # COPY --from=arches_static /usr/share/nginx/html/static/CACHE/manifest.json ${STATIC_ROOT}/CACHE/manifest.json
 COPY --from=arches_static /usr/share/nginx/html ${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}/media/build

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ manage: docker
 
 .PHONY: webpack
 webpack: docker
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /bin/bash arches_worker -c '. ../ENV/bin/activate; cd $(ARCHES_PROJECT); DJANGO_MODE=DEV NODE_PATH=./media/node_modules NODE_OPTIONS=--max_old_space_size=8192 node --inspect ./media/node_modules/.bin/webpack --config webpack/webpack.config.dev.js'
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /bin/bash arches_worker -c '. ../ENV/bin/activate; DJANGO_MODE=DEV NODE_PATH=./node_modules NODE_OPTIONS=--max_old_space_size=8192 node --inspect ./node_modules/.bin/webpack --config webpack/webpack.config.dev.js'
 
 .PHONY: clean
 clean: docker

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base-7.5-dev:coral
+ARCHES_BASE = flaxandteal/arches_base:8.0.3
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker-compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
-ARCHES_BASE = flaxandteal/arches_base:8.0.3
+ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base-7.5-dev:coral
+ARCHES_BASE = ghcr.io/flaxandteal/arches-base:coral
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker-compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=
@@ -67,11 +67,11 @@ build: docker
 	# We need to have certain node modules, so if the additional ones are missing, clean the folder to ensure boostrap does so.
 	if [ -z $(ARCHES_PROJECT)/media/node_modules/jquery-validation ]; then rm -rf $(ARCHES_PROJECT)/media/node_modules; fi
 	$(DOCKER_COMPOSE_COMMAND) stop
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_yarn_components
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_npm_components
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker bootstrap
 
 	if [ -d $(ARCHES_PROJECT)/pkg ]; then $(TOOLKIT_FOLDER)/act.py . load_package --yes; fi
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_yarn_build_development
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_npm_build_development
 	$(DOCKER_COMPOSE_COMMAND) stop
 	@echo "IF THIS IS YOUR FIRST TIME RUNNING make build AND YOU HAVE NOT ALREADY, MAKE SURE TO UPDATE urls.py (see make help)"
 
@@ -96,9 +96,9 @@ web: docker
 	$(DOCKER_COMPOSE_COMMAND) stop arches
 	$(DOCKER_COMPOSE_COMMAND) run --service-ports arches
 
-.PHONY: yarn-development
-yarn-development: docker
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_yarn_build_development
+.PHONY: npm-development
+npm-development: docker
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_npm_build_development
 
 .PHONY: docker-compose
 docker-compose: docker

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ CMD ?=
 
 create: docker
 	echo $(shell id -u)
-	FORUSER=$(shell id -u) $(DOCKER_COMPOSE_COMMAND) run -e FORUSER=$(shell id -u) --entrypoint /bin/sh arches_base -c ". ../ENV/bin/activate; apt install -y git; pip install 'pyjwt<2.1,>=2.0.0' 'cryptography<3.4.0' --only-binary cryptography --only-binary cffi; cd /local_root; ls -ltr; id -u; arches-project create $(ARCHES_PROJECT) && mv docker Makefile $(ARCHES_PROJECT); ls -ltr; echo \$${FORUSER}; groupadd -g \$${FORUSER} externaluser; useradd -u \$${FORUSER} -g \$${FORUSER} externaluser; chown -R \$${FORUSER}:\$${FORUSER} $(ARCHES_PROJECT); echo \$$?; ls -ltr $(ARCHES_PROJECT)"
+	FORUSER=$(shell id -u) $(DOCKER_COMPOSE_COMMAND) run -e FORUSER=$(shell id -u) --entrypoint /bin/sh arches_base -c ". ../ENV/bin/activate; apt install -y git; pip install 'pyjwt<2.1,>=2.0.0' 'cryptography<3.4.0' --only-binary cryptography --only-binary cffi; cd /local_root; ls -ltr; id -u; arches-admin startproject $(ARCHES_PROJECT) && mv docker Makefile $(ARCHES_PROJECT); ls -ltr; echo \$${FORUSER}; groupadd -g \$${FORUSER} externaluser; useradd -u \$${FORUSER} -g \$${FORUSER} externaluser; chown -R \$${FORUSER}:\$${FORUSER} $(ARCHES_PROJECT); echo \$$?; ls -ltr $(ARCHES_PROJECT)"
 
 cypress.config.js: dl-docker
 	cp docker/tests/cypress.config.js $(ARCHES_PROJECT_ROOT)

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifneq ($(ARCHES_ROOT),)
 else
   DOCKER_COMPOSE_FILES = -f docker/docker-compose.yml
 endif
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1
+ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1.0-release
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
 USE_LOCAL_APPS ?= false

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
-ARCHES_BASE = ghcr.io/flaxandteal/arches-base:coral
+ARCHES_BASE = flaxandteal/arches_base:8.0.3
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker-compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
 CMD ?=
 
-.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug
+.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app
 
 create: docker
 	echo $(shell id -u)
@@ -44,6 +44,16 @@ create-apps-dir:
 	else \
     	echo "arches_apps already exists"; \
 	fi
+
+install-app:
+	@if [ -z "$(URL)" ]; then \
+		echo "Error: No GitHub URL provided. Usage: make install-app URL=<repo_url>"; \
+		exit 1; \
+	fi
+	python3 $(TOOLKIT_FOLDER)/install_app.py "$(URL)" --project-root "$(ARCHES_PROJECT_ROOT)"
+	@echo ""
+	@echo "You may need to run python manage.py migrate to install any models in the app"
+	@echo "Make sure to rebuild the project frontend"
 
 update-urls-debug:
 	@if ! grep -q "from django.contrib.staticfiles import views" $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; then \

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ endif
 ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1
 ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
+USE_LOCAL_APPS ?= false
 CMD ?=
 
 .PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app migrate post-create-setup
@@ -125,7 +126,7 @@ endif
 	@if [ "$$(diff Makefile $(TOOLKIT_FOLDER)/Makefile)" != "" ]; then echo "Your Makefile in this directory does not match the one in directory [$(TOOLKIT_FOLDER)], do you need to update it by copying it over this one or vice versa?"; echo; fi
 
 rebuild-images: docker
-	$(DOCKER_COMPOSE_COMMAND) build
+	$(DOCKER_COMPOSE_COMMAND) build --build-arg USE_LOCAL_APPS=$(USE_LOCAL_APPS)
 
 npm-install: docker
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_npm_components

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,11 @@ DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=
 USE_LOCAL_APPS ?= false
 CMD ?=
 
-.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app migrate post-create-setup
+.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app
 
 create: docker
 	echo $(shell id -u)
 	FORUSER=$(shell id -u) $(DOCKER_COMPOSE_COMMAND) run -e FORUSER=$(shell id -u) --entrypoint /bin/sh arches_base -c ". ../ENV/bin/activate; apt install -y git; pip install 'pyjwt<2.1,>=2.0.0' 'cryptography<3.4.0' --only-binary cryptography --only-binary cffi; cd /local_root; ls -ltr; id -u; arches-admin startproject $(ARCHES_PROJECT) && mv docker Makefile $(ARCHES_PROJECT); ls -ltr; echo \$${FORUSER}; groupadd -g \$${FORUSER} externaluser; useradd -u \$${FORUSER} -g \$${FORUSER} externaluser; chown -R \$${FORUSER}:\$${FORUSER} $(ARCHES_PROJECT); echo \$$?; ls -ltr $(ARCHES_PROJECT)"
-	@echo ""
-	@echo "Project created! Run 'make post-create-setup' to update GitHub Actions and pyproject.toml for compatibility."
 
 post-create-setup:
 	@echo "Updating project configuration files..."
@@ -77,20 +75,20 @@ create-apps-dir:
 
 install-app:
 	@if [ -z "$(URL)" ]; then \
-		echo "Error: No GitHub URL provided. Usage: make install-app URL=<repo_url>"; \
+		echo "Error: No GitHub URL provided. Usage: make install-app URL=<repo_url> [BRANCH=<branch>]"; \
 		exit 1; \
 	fi
-	python3 $(TOOLKIT_FOLDER)/install_app.py "$(URL)" --project-root "$(ARCHES_PROJECT_ROOT)"
+	python3 $(TOOLKIT_FOLDER)/install_app.py "$(URL)" $(if $(BRANCH),--branch "$(BRANCH)") --project-root "$(ARCHES_PROJECT_ROOT)"
 	@echo ""
 	@echo "You may need to run python manage.py migrate to install any models in the app"
 	@echo "Make sure to rebuild the project frontend"
 
 update-urls-debug:
 	@if ! grep -q "from django.contrib.staticfiles import views" $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; then \
-		echo "Adding DEBUG static file serving to urls.py"; \
-		echo "\nif settings.DEBUG:\n    from django.contrib.staticfiles import views\n    from django.urls import re_path\n    urlpatterns += [\n        re_path(r'^static/(?P<path>.*)$$', views.serve),\n    ]\n" >> $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; \
+    	echo "Adding DEBUG static file serving to urls.py"; \
+    	echo "\nif settings.DEBUG:\n    from django.contrib.staticfiles import views\n    from django.urls import re_path\n    urlpatterns += [\n        re_path(r'^static/(?P<path>.*)$', views.serve),\n    ]" >> $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; \
 	else \
-		echo "DEBUG static file serving already exists in urls.py"; \
+    	echo "DEBUG static file serving already exists in urls.py"; \
 	fi
 
 dl-docker:
@@ -134,10 +132,6 @@ npm-install: docker
 npm-update: docker
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker update_npm_components
 
-install-local-apps:
-	@echo "Installing apps from mounted arches_apps directory in editable mode..."
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_arches_apps
-
 build: docker
 	# We need to have certain node modules, so if the additional ones are missing, clean the folder to ensure boostrap does so.
 	if [ -z node_modules/jquery-validation ]; then rm -rf node_modules; fi
@@ -150,10 +144,6 @@ build: docker
 	$(DOCKER_COMPOSE_COMMAND) stop
 	$(MAKE) create-apps-dir
 	$(MAKE) update-urls-debug
-
-migrate: docker
-	$(MAKE) install-local-apps
-	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /bin/bash arches_worker -c '. ../ENV/bin/activate; python manage.py migrate'
 
 create-github-action: cypress docker
 	mkdir -p  $(ARCHES_PROJECT_ROOT).github/workflows
@@ -206,11 +196,6 @@ help:
 	@echo "To set up a new project, ensure the ARCHES_PROJECT above is correct, then run 'make build', followed by 'make run'."
 	@echo "If you do not see a project above or it is wrong, ensure that there is exactly one subfolder of this directory with an"
 	@echo "__init__.py file."
-	@echo
-	@echo "After creating a new project with 'make create', you can run 'make post-create-setup' to update configuration files:"
-	@echo "  - Updates .github/workflows/main.yml PostGIS image: postgis/postgis:14-3.4 → ghcr.io/flaxandteal/arches-postgis:docker-8.1"
-	@echo "  - Updates .github/workflows/main.yml to use the correct base image"
-	@echo "  - Updates pyproject.toml to change arches>=8.1 to arches>=8.0.0"
 	@echo
 	@echo "Note that '$(ARCHES_PROJECT)/urls.py' must have (manually added):"
 	@echo "	if settings.DEBUG:"

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ post-create-setup:
 	fi
 	@# Update pyproject.toml Arches version constraint
 	@if [ -f "$(ARCHES_PROJECT_ROOT)pyproject.toml" ]; then \
-		sed -i.bak 's/arches>=8\.1/arches>=8.0.0/g' $(ARCHES_PROJECT_ROOT)pyproject.toml && \
+		sed -i.bak 's/arches>=8\.1\.0/arches>=8.0.0/g' $(ARCHES_PROJECT_ROOT)pyproject.toml && \
 		rm -f $(ARCHES_PROJECT_ROOT)pyproject.toml.bak && \
-		echo "✓ Updated pyproject.toml: arches>=8.1 → arches>=8.0.0"; \
+		echo "✓ Updated pyproject.toml: arches>=8.1.0 → arches>=8.0.0"; \
 	else \
 		echo "⚠ pyproject.toml not found, skipping..."; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,23 @@ TOOLKIT_REPO = https://github.com/flaxandteal/arches-container-toolkit
 TOOLKIT_FOLDER = docker
 TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
+ifeq ($(wildcard /../arches),)
+	ARCHES_ROOT=$(realpath ../arches)
+else
+	
+	ARCHES_ROOT=
+endif
+ifneq ($(ARCHES_ROOT),)
+  DOCKER_COMPOSE_FILES = -f docker/docker-compose.yml -f docker/docker-compose.volumes.yml
+else
+  DOCKER_COMPOSE_FILES = -f docker/docker-compose.yml
+endif
 ARCHES_BASE = ghcr.io/flaxandteal/arches-base:docker-8.1
 ARCHES_PROJECT_ROOT = $(shell pwd)/
-DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
+DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
 CMD ?=
 
-.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help
+.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug
 
 create: docker
 	echo $(shell id -u)
@@ -24,6 +35,23 @@ cypress: cypress.config.js
 test: cypress
 
 docker: dl-docker
+
+create-apps-dir:
+	@if [ ! -d "../arches_apps" ]; then \
+    	mkdir -p "../arches_apps"; \
+		APPS_DIR=../arches_apps \
+    	echo "Created arches_apps directory"; \
+	else \
+    	echo "arches_apps already exists"; \
+	fi
+
+update-urls-debug:
+	@if ! grep -q "from django.contrib.staticfiles import views" $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; then \
+    	echo "Adding DEBUG static file serving to urls.py"; \
+    	echo "\nif settings.DEBUG:\n    from django.contrib.staticfiles import views\n    from django.urls import re_path\n    urlpatterns += [\n        re_path(r'^static/(?P<path>.*)$', views.serve),\n    ]" >> $(ARCHES_PROJECT_ROOT)/$(ARCHES_PROJECT)/urls.py; \
+	else \
+    	echo "DEBUG static file serving already exists in urls.py"; \
+	fi
 
 dl-docker:
 	@echo ARCHES_PROJECT is [$(ARCHES_PROJECT)]
@@ -60,6 +88,12 @@ endif
 rebuild-images: docker
 	$(DOCKER_COMPOSE_COMMAND) build
 
+npm-install: docker
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_npm_components
+
+npm-update: docker
+	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker update_npm_components
+
 build: docker
 	# We need to have certain node modules, so if the additional ones are missing, clean the folder to ensure boostrap does so.
 	if [ -z node_modules/jquery-validation ]; then rm -rf node_modules; fi
@@ -70,7 +104,8 @@ build: docker
 	if [ -d $(ARCHES_PROJECT)/pkg ]; then $(TOOLKIT_FOLDER)/act.py . load_package --yes; fi
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_npm_build_development
 	$(DOCKER_COMPOSE_COMMAND) stop
-	@echo "IF THIS IS YOUR FIRST TIME RUNNING make build AND YOU HAVE NOT ALREADY, MAKE SURE TO UPDATE urls.py (see make help)"
+	$(MAKE) create-apps-dir
+	$(MAKE) update-urls-debug
 
 create-github-action: cypress docker
 	mkdir -p  $(ARCHES_PROJECT_ROOT).github/workflows

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ TOOLKIT_RELEASE = main
 ARCHES_PROJECT ?= $(shell ls -1 */__init__.py | head -n 1 | sed 's/\/.*//g')
 ARCHES_BASE = flaxandteal/arches_base:8.0.3
 ARCHES_PROJECT_ROOT = $(shell pwd)/
-DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker-compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
+DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) docker compose -p $(ARCHES_PROJECT) -f docker/docker-compose.yml
 CMD ?=
+
+.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help
 
 create: docker
 	echo $(shell id -u)
@@ -17,13 +19,10 @@ cypress.config.js: dl-docker
 	cp docker/tests/cypress.config.js $(ARCHES_PROJECT_ROOT)
 	cp -R docker/tests/cypress $(ARCHES_PROJECT_ROOT)
 
-.PHONY: cypress
 cypress: cypress.config.js
 
-.PHONY: test
 test: cypress
 
-.PHONY: docker
 docker: dl-docker
 
 dl-docker:
@@ -58,14 +57,12 @@ endif
 endif
 	@if [ "$$(diff Makefile $(TOOLKIT_FOLDER)/Makefile)" != "" ]; then echo "Your Makefile in this directory does not match the one in directory [$(TOOLKIT_FOLDER)], do you need to update it by copying it over this one or vice versa?"; echo; fi
 
-.PHONY: rebuild-images
 rebuild-images: docker
 	$(DOCKER_COMPOSE_COMMAND) build
 
-.PHONY: build
 build: docker
 	# We need to have certain node modules, so if the additional ones are missing, clean the folder to ensure boostrap does so.
-	if [ -z $(ARCHES_PROJECT)/media/node_modules/jquery-validation ]; then rm -rf $(ARCHES_PROJECT)/media/node_modules; fi
+	if [ -z node_modules/jquery-validation ]; then rm -rf node_modules; fi
 	$(DOCKER_COMPOSE_COMMAND) stop
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker install_npm_components
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker bootstrap
@@ -75,7 +72,6 @@ build: docker
 	$(DOCKER_COMPOSE_COMMAND) stop
 	@echo "IF THIS IS YOUR FIRST TIME RUNNING make build AND YOU HAVE NOT ALREADY, MAKE SURE TO UPDATE urls.py (see make help)"
 
-.PHONY: create-github-action
 create-github-action: cypress docker
 	mkdir -p  $(ARCHES_PROJECT_ROOT).github/workflows
 	cp $(TOOLKIT_FOLDER)/project.yml $(ARCHES_PROJECT_ROOT).github/workflows
@@ -83,15 +79,12 @@ create-github-action: cypress docker
 	sed -i "s#__ARCHESBASE__#$(ARCHES_BASE)#g" $(ARCHES_PROJECT_ROOT).github/workflows/project.yml
 	@echo "You will now need to git-add your .github folder and commit it. On your next push, you should find Arches builds."
 
-.PHONY: down
 down: docker
 	$(DOCKER_COMPOSE_COMMAND) down
 
-.PHONY: run
 run: docker
 	$(DOCKER_COMPOSE_COMMAND) up
 
-.PHONY: web
 web: docker
 	$(DOCKER_COMPOSE_COMMAND) stop arches
 	$(DOCKER_COMPOSE_COMMAND) run --service-ports arches
@@ -100,24 +93,19 @@ web: docker
 npm-development: docker
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /web_root/entrypoint.sh arches_worker run_npm_build_development
 
-.PHONY: docker-compose
 docker-compose: docker
 	$(DOCKER_COMPOSE_COMMAND) $(shell echo $(CMD))
 
-.PHONY: manage
 manage: docker
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /bin/bash arches_worker -c '. ../ENV/bin/activate; python manage.py $(CMD)'
 
-.PHONY: webpack
 webpack: docker
 	$(DOCKER_COMPOSE_COMMAND) run --entrypoint /bin/bash arches_worker -c '. ../ENV/bin/activate; DJANGO_MODE=DEV NODE_PATH=./node_modules NODE_OPTIONS=--max_old_space_size=8192 node --inspect ./node_modules/.bin/webpack --config webpack/webpack.config.dev.js'
 
-.PHONY: clean
 clean: docker
 	@echo -n "This will remove all database and elasticsearch data, are you sure? [y/N] " && read confirmation && [ $${confirmation:-N} = y ]
 	$(DOCKER_COMPOSE_COMMAND) down -v --rmi all
 
-.PHONY: help
 help:
 	@echo
 	@echo "ARCHES F&T CONTAINER TOOLS"

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,40 @@ ARCHES_PROJECT_ROOT = $(shell pwd)/
 DOCKER_COMPOSE_COMMAND = ARCHES_PROJECT_ROOT=$(ARCHES_PROJECT_ROOT) ARCHES_BASE=$(ARCHES_BASE) ARCHES_PROJECT=$(ARCHES_PROJECT) ARCHES_ROOT=$(ARCHES_ROOT) docker compose -p $(ARCHES_PROJECT) $(DOCKER_COMPOSE_FILES)
 CMD ?=
 
-.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app migrate
+.PHONY: cypress test docker rebuild-images build create-github-action down run web npm-development docker-compose manage webpack clean help npm-install npm-update create-apps-dir update-urls-debug install-app migrate post-create-setup
 
 create: docker
 	echo $(shell id -u)
 	FORUSER=$(shell id -u) $(DOCKER_COMPOSE_COMMAND) run -e FORUSER=$(shell id -u) --entrypoint /bin/sh arches_base -c ". ../ENV/bin/activate; apt install -y git; pip install 'pyjwt<2.1,>=2.0.0' 'cryptography<3.4.0' --only-binary cryptography --only-binary cffi; cd /local_root; ls -ltr; id -u; arches-admin startproject $(ARCHES_PROJECT) && mv docker Makefile $(ARCHES_PROJECT); ls -ltr; echo \$${FORUSER}; groupadd -g \$${FORUSER} externaluser; useradd -u \$${FORUSER} -g \$${FORUSER} externaluser; chown -R \$${FORUSER}:\$${FORUSER} $(ARCHES_PROJECT); echo \$$?; ls -ltr $(ARCHES_PROJECT)"
+	@echo ""
+	@echo "Project created! Run 'make post-create-setup' to update GitHub Actions and pyproject.toml for compatibility."
+
+post-create-setup:
+	@echo "Updating project configuration files..."
+	@# Update GitHub Actions workflow - PostGIS image
+	@if [ -f "$(ARCHES_PROJECT_ROOT).github/workflows/main.yml" ]; then \
+		sed -i.bak 's|postgis/postgis:14-3\.4|ghcr.io/flaxandteal/arches-postgis:docker-8.1|g' $(ARCHES_PROJECT_ROOT).github/workflows/main.yml && \
+		echo "✓ Updated .github/workflows/main.yml PostGIS image: postgis/postgis:14-3.4 → ghcr.io/flaxandteal/arches-postgis:docker-8.1"; \
+	else \
+		echo "⚠ .github/workflows/main.yml not found, skipping PostGIS update..."; \
+	fi
+	@# Update GitHub Actions workflow - Arches base image
+	@if [ -f "$(ARCHES_PROJECT_ROOT).github/workflows/main.yml" ]; then \
+		sed -i.bak 's|ghcr.io/flaxandteal/arches-base:docker-8.1|$(ARCHES_BASE)|g' $(ARCHES_PROJECT_ROOT).github/workflows/main.yml && \
+		rm -f $(ARCHES_PROJECT_ROOT).github/workflows/main.yml.bak && \
+		echo "✓ Updated .github/workflows/main.yml Arches base image: $(ARCHES_BASE)"; \
+	else \
+		echo "⚠ .github/workflows/main.yml not found, skipping base image update..."; \
+	fi
+	@# Update pyproject.toml Arches version constraint
+	@if [ -f "$(ARCHES_PROJECT_ROOT)pyproject.toml" ]; then \
+		sed -i.bak 's/arches>=8\.1/arches>=8.0.0/g' $(ARCHES_PROJECT_ROOT)pyproject.toml && \
+		rm -f $(ARCHES_PROJECT_ROOT)pyproject.toml.bak && \
+		echo "✓ Updated pyproject.toml: arches>=8.1 → arches>=8.0.0"; \
+	else \
+		echo "⚠ pyproject.toml not found, skipping..."; \
+	fi
+	@echo "Post-create setup complete!"
 
 cypress.config.js: dl-docker
 	cp docker/tests/cypress.config.js $(ARCHES_PROJECT_ROOT)
@@ -176,6 +205,11 @@ help:
 	@echo "To set up a new project, ensure the ARCHES_PROJECT above is correct, then run 'make build', followed by 'make run'."
 	@echo "If you do not see a project above or it is wrong, ensure that there is exactly one subfolder of this directory with an"
 	@echo "__init__.py file."
+	@echo
+	@echo "After creating a new project with 'make create', you can run 'make post-create-setup' to update configuration files:"
+	@echo "  - Updates .github/workflows/main.yml PostGIS image: postgis/postgis:14-3.4 → ghcr.io/flaxandteal/arches-postgis:docker-8.1"
+	@echo "  - Updates .github/workflows/main.yml to use the correct base image"
+	@echo "  - Updates pyproject.toml to change arches>=8.1 to arches>=8.0.0"
 	@echo
 	@echo "Note that '$(ARCHES_PROJECT)/urls.py' must have (manually added):"
 	@echo "	if settings.DEBUG:"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You probably want [the standard tooling](https://arches.readthedocs.io/en/stable
 ### I have no existing Arches project, but can use `arches-project` command
 
 Install the `arches-project` tool as per the [Arches documentation](https://arches.readthedocs.io/en/stable/).
-Note that it requires `yarn` as a dependency. Run:
+Note that it requires `npm` as a dependency. Run:
 
 ```
   arches-project create MYPROJECTNAME

--- a/act.py
+++ b/act.py
@@ -30,6 +30,8 @@ class ArchesProject:
     def _get_arches_project_name(root: Path):
         project_name = None
         for submodule in root.glob("*/__init__.py"):
+            if submodule.parts[0] == "tests":
+                continue
             if project_name:
                 raise RuntimeError("There should be exactly one Python package in the project root!")
             name = str(submodule.parent.parts[-1])

--- a/act.py
+++ b/act.py
@@ -25,6 +25,7 @@ from pathlib import Path
 
 PROGRAM = "Arches F&T Container Toolkit"
 
+
 class ArchesProject:
     @staticmethod
     def _get_arches_project_name(root: Path):
@@ -33,14 +34,16 @@ class ArchesProject:
             if submodule.parts[0] == "tests":
                 continue
             if project_name:
-                raise RuntimeError("There should be exactly one Python package in the project root!")
+                raise RuntimeError(
+                    "There should be exactly one Python package in the project root!"
+                )
             name = str(submodule.parent.parts[-1])
-            if name in ['tests']:
+            if name in ["tests"]:
                 continue
             project_name = name
         if not project_name:
             raise RuntimeError("Could not find a Python project in the project root!")
-        
+
         return project_name
 
     def __init__(self, root):
@@ -62,20 +65,30 @@ class ArchesProject:
             if force:
                 shutil.rmtree(self.package_folder)
             else:
-                raise RuntimeError(f"A package has already been imported, please remove it from {self.package_folder} first!")
+                raise RuntimeError(
+                    f"A package has already been imported, please remove it from {self.package_folder} first!"
+                )
         print(f"Copying from {location} to {self.package_folder}")
         shutil.copytree(location, self.package_folder)
-        do_import = input("Do you wish to do the installation to the database now? [y/N] ")
+        do_import = input(
+            "Do you wish to do the installation to the database now? [y/N] "
+        )
         if do_import == "y":
             self.load_package()
 
     def load_package(self, all_yes=False, load_business_data=True):
         if not self.package_folder.exists():
-            raise RuntimeError(f"A package has not been imported, please provide one with import_package first!")
+            raise RuntimeError(
+                f"A package has not been imported, please provide one with import_package first!"
+            )
         print("Installing to DB with Makefile")
         if self.ontologies_folder.exists():
             self.run_manage_command(["load_ontology", "-s", self.ontologies_folder])
-        self.run_manage_command(["packages", "-o", "load_package", "-s", self.package_folder] + (["-y"] if all_yes else []) + (["--no-business_data"] if not load_business_data else []))
+        self.run_manage_command(
+            ["packages", "-o", "load_package", "-s", self.package_folder]
+            + (["-y"] if all_yes else [])
+            + (["--no-business_data"] if not load_business_data else [])
+        )
 
     def wait_for_db(self):
         self.run_entrypoint_command(["wait_for_db"])
@@ -83,46 +96,68 @@ class ArchesProject:
     def run_entrypoint_command(self, args):
         os.chdir(self.root)
         entrypoint_command = " ".join(map(str, args))
-        subprocess.run([
-            "make", "docker-compose",
-            "CMD=\"run --entrypoint ../entrypoint.sh "
-            f"arches_worker {entrypoint_command}\""
-        ])
+        subprocess.run(
+            [
+                "make",
+                "docker-compose",
+                'CMD="run --entrypoint ../entrypoint.sh '
+                f'arches_worker {entrypoint_command}"',
+            ]
+        )
 
     def run_manage_command(self, args):
         os.chdir(self.root)
         manage_command = " ".join(map(str, args))
-        subprocess.run([
-            "make", "docker-compose",
-            "CMD=\"run --entrypoint /bin/sh "
-            "arches_worker -c "
-            f"\\\". ../ENV/bin/activate; ../entrypoint.sh install_arches_apps; python manage.py {manage_command}\\\"\""
-        ])
+        subprocess.run(
+            [
+                "make",
+                "docker-compose",
+                'CMD="run --entrypoint /bin/sh '
+                "arches_worker -c "
+                f'\\". ../ENV/bin/activate; ../entrypoint.sh install_arches_apps; python manage.py {manage_command}\\""',
+            ]
+        )
 
 
 def run(args):
     parser = argparse.ArgumentParser(prog=PROGRAM)
-    parser.add_argument('root', type=str, help='gives the location of the project root')
+    parser.add_argument("root", type=str, help="gives the location of the project root")
     subparsers = parser.add_subparsers(required=True)
 
-    parser_ip = subparsers.add_parser('import_package', help='imports a package into the existing tree')
-    parser_ip.add_argument('location', type=str, help='Folder containing package to import')
-    parser_ip.add_argument('--force', action='store_true', help='Delete target package folder if it exists')
+    parser_ip = subparsers.add_parser(
+        "import_package", help="imports a package into the existing tree"
+    )
+    parser_ip.add_argument(
+        "location", type=str, help="Folder containing package to import"
+    )
+    parser_ip.add_argument(
+        "--force", action="store_true", help="Delete target package folder if it exists"
+    )
+
     def import_package(project, args):
         project.wait_for_db()
         project.import_package(Path(args.location), args.force)
+
     parser_ip.set_defaults(func=import_package)
 
-    parser_lp = subparsers.add_parser('load_package', help='installs a package into the database')
-    parser_lp.add_argument('--yes', action='store_true')
+    parser_lp = subparsers.add_parser(
+        "load_package", help="installs a package into the database"
+    )
+    parser_lp.add_argument("--yes", action="store_true")
+
     def load_package(project, args):
         project.wait_for_db()
-        project.load_package(all_yes=args.yes, load_business_data=not (os.getenv("NO_LOAD_BUSINESS_DATA", "") == "1"))
+        project.load_package(
+            all_yes=args.yes,
+            load_business_data=not (os.getenv("NO_LOAD_BUSINESS_DATA", "") == "1"),
+        )
+
     parser_lp.set_defaults(func=load_package)
 
     args = parser.parse_args(args)
     project = ArchesProject(Path(args.root))
     args.func(project, args)
+
 
 if __name__ == "__main__":
 

--- a/act.py
+++ b/act.py
@@ -96,7 +96,7 @@ class ArchesProject:
             "make", "docker-compose",
             "CMD=\"run --entrypoint /bin/sh "
             "arches_worker -c "
-            f"\\\". ../ENV/bin/activate; python manage.py {manage_command}\\\"\""
+            f"\\\". ../ENV/bin/activate; ../entrypoint.sh install_arches_apps; python manage.py {manage_command}\\\"\""
         ])
 
 

--- a/act.py
+++ b/act.py
@@ -29,6 +29,9 @@ PROGRAM = "Arches F&T Container Toolkit"
 class ArchesProject:
     @staticmethod
     def _get_arches_project_name(root: Path):
+        env_name = os.environ.get("ARCHES_PROJECT")
+        if env_name:
+            return env_name
         project_name = None
         for submodule in root.glob("*/__init__.py"):
             if submodule.parts[0] == "tests":

--- a/docker-compose.volumes.yml
+++ b/docker-compose.volumes.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   arches:
     volumes:

--- a/docker-compose.volumes.yml
+++ b/docker-compose.volumes.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+services:
+  arches:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+  arches_api:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+  arches_worker:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+  arches_base:
+    volumes:
+      - ${ARCHES_ROOT}:/web_root/arches
+      - ${ARCHES_ROOT}/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
 
     arches:
       restart: unless-stopped
+      user: root # frontend configuration
       entrypoint: ["../entrypoint.sh"]
       build:
         context: ${ARCHES_PROJECT_ROOT}.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,8 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
@@ -110,8 +111,9 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
-        #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.10/site-packages/graphql
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.12/site-packages/graphql
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - GUNICORN_WORKERS=1
@@ -164,7 +166,8 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,9 +198,9 @@ services:
     db:
       # NOTE: due to a race condition, this needs docker-compose run db first to ensure
       # template directory created
-      image: kartoza/postgis:12.0
+      image: postgis/postgis:14-3.2
       volumes:
-          - postgres-data:/var/lib/postgresql
+          - postgres-data:/var/lib/postgresql/data
           - postgres-log:/var/log/postgresql
           - ${ARCHES_PROJECT_ROOT}./docker/init-unix.sql:/docker-entrypoint-initdb.d/init.sql # to set up the DB template
       ports:
@@ -209,16 +209,12 @@ services:
         - '5432'
       environment:
         - POSTGRES_USER=postgres
-        - POSTGRES_PASS=postgres
-        - POSTGRESQL_USER=postgres
-        - POSTGRESQL_PASS=postgres
+        - POSTGRES_PASSWORD=postgres
         - POSTGRES_DB=postgres
-        - POSTGRES_MULTIPLE_EXTENSIONS=postgis,postgis_topology
-        - SHARED_PRELOAD_LIBRARIES=pg_stat_statements
         - TZ=PST
 
     elasticsearch:
-      image: elasticsearch:8.4.0
+      image: elasticsearch:9.0.4
       volumes:
         - elasticsearch-data:/usr/share/elasticsearch/data
       ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,13 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        # $ARCHES_ROOT:/web_root/arches
-        # $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+        - $ARCHES_ROOT:/web_root/arches
+        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
@@ -103,15 +104,17 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        # $ARCHES_ROOT:/web_root/arches
-        # $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+        - $ARCHES_ROOT:/web_root/arches
+        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.10/site-packages/graphql
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
+        - GUNICORN_WORKERS=1
         - INSTALL_DEFAULT_GRAPHS=False
         - INSTALL_DEFAULT_CONCEPTS=False
         - GUNICORN_WORKER_TIMEOUT=300
@@ -124,6 +127,7 @@ services:
         - ESPORT=9200
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
+        - DEBUG=True
         # - DJANGO_REMOTE_DEBUG=False
         - DOMAIN_NAMES=localhost
         - PYTHONUNBUFFERED=0
@@ -154,13 +158,13 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        # $ARCHES_ROOT:/web_root/arches
-        # $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
+        - $ARCHES_ROOT:/web_root/arches
+        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
         # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
@@ -195,8 +199,8 @@ services:
       # template directory created
       image: kartoza/postgis:12.0
       volumes:
-          - postgres-data:/var/lib/postgresql
-          - postgres-log:/var/log/postgresql
+          - postgres2-data:/var/lib/postgresql
+          - postgres2-log:/var/log/postgresql
           - ${ARCHES_PROJECT_ROOT}./docker/init-unix.sql:/docker-entrypoint-initdb.d/init.sql # to set up the DB template
       ports:
         - '5432:5432'
@@ -235,7 +239,7 @@ services:
 volumes:
     arches-log:
     arches-static:
-    postgres-log:
-    postgres-data:
+    postgres2-log:
+    postgres2-data:
     elasticsearch-data:
     cantaloupe-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,9 +56,10 @@ services:
         - CANTALOUPE_PORT=8182
         - COMPRESS_ENABLED=False
         - WEB_ROOT=/web_root
+        - WEBPACK_DEVELOPMENT_SERVER_PORT=9000
 
       ports:
-        - '8000:8000'
+      - '8000:8000'
       depends_on:
         - db
         - elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
         - 8182:8182
 
     arches:
+      user: root
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
@@ -26,8 +27,10 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
-        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
+        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
+        # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
@@ -111,8 +114,10 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
-        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
+        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
         #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.12/site-packages/graphql
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -166,8 +171,10 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
-        - ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
+        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
+        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
+        # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,6 @@ services:
 
     arches:
       restart: unless-stopped
-      user: root # frontend configuration
       entrypoint: ["../entrypoint.sh"]
       build:
         context: ${ARCHES_PROJECT_ROOT}.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
         - ESHOST=elasticsearch
         - ESPORT=9200
         - CELERY_BROKER_URL=amqp://rabbitmq:rabbitmq@rabbitmq
-        - DJANGO_MODE=PROD
+        - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
         - DOMAIN_NAMES=localhost
         - PYTHONUNBUFFERED=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}./..
+        context: ${ARCHES_PROJECT_ROOT}.
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -24,6 +24,7 @@ services:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
+        - node-modules:/web_root/$ARCHES_PROJECT/node_modules
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
         - ${ARCHES_PROJECT_ROOT}./../arches:/web_root/arches
@@ -46,6 +47,7 @@ services:
         - CELERY_BROKER_URL=amqp://rabbitmq:rabbitmq@rabbitmq
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
+        - DJANGO_INSECURE_COOKIES=True
         - DOMAIN_NAMES=localhost
         - PYTHONUNBUFFERED=0
         - TZ=PST
@@ -103,7 +105,7 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}./..
+        context: ${ARCHES_PROJECT_ROOT}.
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -116,6 +118,7 @@ services:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
+        - node-modules:/web_root/$ARCHES_PROJECT/node_modules
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
         - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
@@ -137,6 +140,7 @@ services:
         - ESPORT=9200
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
+        - DJANGO_INSECURE_COOKIES=True
         - DEBUG=True
         # - DJANGO_REMOTE_DEBUG=False
         - DOMAIN_NAMES=localhost
@@ -163,7 +167,7 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}./..
+        context: ${ARCHES_PROJECT_ROOT}.
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -176,6 +180,7 @@ services:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
+        - node-modules:/web_root/$ARCHES_PROJECT/node_modules
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
         - ${ARCHES_PROJECT_ROOT}./../arches:/web_root/arches
@@ -193,6 +198,7 @@ services:
         - ESPORT=9200
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
+        - DJANGO_INSECURE_COOKIES=True
         - CASBIN_RELOAD_QUEUE=True
         - CASBIN_LISTEN=True
         # - DJANGO_REMOTE_DEBUG=False
@@ -292,3 +298,4 @@ volumes:
     postgres-data:
     elasticsearch-data:
     cantaloupe-data:
+    node-modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=True
+          - EDITABLE_BASE=False
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_arches
       volumes:
@@ -168,7 +168,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=True
+          - EDITABLE_BASE=False
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_celery
       user: root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,8 @@ services:
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches
+        - PGDBNAME=arches2
+        - CASBIN_RELOAD_QUEUE=True
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -79,7 +80,7 @@ services:
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches
+        - PGDBNAME=arches2
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -127,7 +128,7 @@ services:
         - GUNICORN_WORKER_TIMEOUT=300
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches
+        - PGDBNAME=arches2
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -171,23 +172,21 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
-        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
-        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
-        # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
+        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches
+        - PGDBNAME=arches2
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
         - ESPORT=9200
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
+        - CASBIN_RELOAD_QUEUE=True
         # - DJANGO_REMOTE_DEBUG=False
         - DOMAIN_NAMES=localhost
         - PYTHONUNBUFFERED=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,13 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}.
+        context: ${ARCHES_PROJECT_ROOT}./..
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
           - EDITABLE_BASE=True
+          - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_arches
       volumes:
         
@@ -97,11 +98,12 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}.
+        context: ${ARCHES_PROJECT_ROOT}./..
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
+          - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_api
       ports:
         - '8001:8000'
@@ -151,12 +153,13 @@ services:
       restart: unless-stopped
       entrypoint: ["../entrypoint.sh"]
       build:
-        context: ${ARCHES_PROJECT_ROOT}.
+        context: ${ARCHES_PROJECT_ROOT}./..
         dockerfile: ${ARCHES_PROJECT_ROOT}./docker/Dockerfile
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
           - EDITABLE_BASE=True
+          - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_celery
       user: root
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,14 +19,13 @@ services:
           - ARCHES_BASE=$ARCHES_BASE
       command: run_arches
       volumes:
+        
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
-        # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
+        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
         # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
@@ -111,12 +110,10 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
-        # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
+        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
         # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
@@ -168,13 +165,10 @@ services:
       volumes:
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
-        - $ARCHES_ROOT:/web_root/arches
-        - $ARCHES_ROOT/docker/gunicorn_config.py:/web_root/arches/gunicorn_config.py
-        # ./$ARCHES_PROJECT/media/node_modules/arches/docker/gunicorn_config.py:/web_root/arches/arches/gunicorn_config.py
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        # - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=True
+          - EDITABLE_BASE=False
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_arches
       volumes:
@@ -59,6 +59,7 @@ services:
         - COMPRESS_ENABLED=False
         - WEB_ROOT=/web_root
         - WEBPACK_DEVELOPMENT_SERVER_PORT=9000
+        - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
 
       ports:
       - '8000:8000'
@@ -142,6 +143,7 @@ services:
         - CANTALOUPE_HOST=cantaloupe
         - CANTALOUPE_PORT=8182
         - TZ=PST
+        - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       depends_on:
         - db
         - elasticsearch
@@ -158,7 +160,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=True
+          - EDITABLE_BASE=False
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_celery
       user: root
@@ -193,6 +195,7 @@ services:
         - CANTALOUPE_HOST=cantaloupe
         - CANTALOUPE_PORT=8182
         - TZ=PST
+        - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       depends_on:
         - db
         - elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
+          - EDITABLE_BASE=True
       command: run_arches
       volumes:
         
@@ -155,6 +156,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
+          - EDITABLE_BASE=True
       command: run_celery
       user: root
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,16 +16,17 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=False
+          - EDITABLE_BASE=True
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_arches
       volumes:
-        
+
         - arches-log:/arches/arches/logs
         - arches-static:/static_root
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
+        - ${ARCHES_PROJECT_ROOT}./../arches:/web_root/arches
         - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
@@ -64,9 +65,12 @@ services:
       ports:
       - '8000:8000'
       depends_on:
-        - db
-        - elasticsearch
-        - cantaloupe
+        db:
+          condition: service_healthy
+        elasticsearch:
+          condition: service_healthy
+        cantaloupe:
+          condition: service_started
 
     arches_base:
       profiles: ["base"]
@@ -145,10 +149,14 @@ services:
         - TZ=PST
         - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       depends_on:
-        - db
-        - elasticsearch
-        - rabbitmq
-        - cantaloupe
+        db:
+          condition: service_healthy
+        elasticsearch:
+          condition: service_healthy
+        rabbitmq:
+          condition: service_started
+        cantaloupe:
+          condition: service_started
 
     arches_worker:
       image: arches_${ARCHES_PROJECT}:latest
@@ -160,7 +168,7 @@ services:
         args:
           - ARCHES_PROJECT=$ARCHES_PROJECT
           - ARCHES_BASE=$ARCHES_BASE
-          - EDITABLE_BASE=False
+          - EDITABLE_BASE=True
           - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       command: run_celery
       user: root
@@ -170,6 +178,7 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
+        - ${ARCHES_PROJECT_ROOT}./../arches:/web_root/arches
         - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -197,11 +206,16 @@ services:
         - TZ=PST
         - USE_LOCAL_APPS=${USE_LOCAL_APPS:-false}
       depends_on:
-        - db
-        - elasticsearch
-        - rabbitmq
-        - arches
-        - cantaloupe
+        db:
+          condition: service_healthy
+        elasticsearch:
+          condition: service_healthy
+        rabbitmq:
+          condition: service_started
+        arches:
+          condition: service_started
+        cantaloupe:
+          condition: service_started
 
     db:
       # NOTE: due to a race condition, this needs docker-compose run db first to ensure
@@ -220,6 +234,17 @@ services:
         - POSTGRES_PASSWORD=postgres
         - POSTGRES_DB=postgres
         - TZ=PST
+      command: >
+        postgres
+          -c shared_buffers=256MB
+          -c fsync=off
+          -c synchronous_commit=off
+          -c full_page_writes=off
+      healthcheck:
+        test: ["CMD-SHELL", "pg_isready -U postgres"]
+        interval: 5s
+        timeout: 5s
+        retries: 10
 
     elasticsearch:
       image: elasticsearch:9.0.4
@@ -228,12 +253,29 @@ services:
       ports:
         - "9200:9200"
         - "9300:9300"
+      ulimits:
+        memlock:
+          soft: -1
+          hard: -1
       environment:
         - TZ=PST
         - discovery.type=single-node
         - discovery.seed_hosts=[]
         - xpack.security.enabled=false
-        - "ES_JAVA_OPTS=-Xms400m -Xmx400m"
+        - xpack.ml.enabled=false
+        - xpack.watcher.enabled=false
+        - xpack.monitoring.collection.enabled=false
+        - bootstrap.memory_lock=true
+        - cluster.routing.allocation.disk.threshold_enabled=false
+        - action.auto_create_index=true
+        - indices.recovery.max_bytes_per_sec=200mb
+        - "ES_JAVA_OPTS=-Xms2g -Xmx2g -XX:+UseG1GC -XX:InitiatingHeapOccupancyPercent=75"
+      healthcheck:
+        test: ["CMD-SHELL", "curl -sf http://localhost:9200/_cluster/health?wait_for_status=yellow || exit 1"]
+        interval: 10s
+        timeout: 10s
+        retries: 20
+        start_period: 30s
 
     rabbitmq:
       image: rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -282,7 +282,9 @@ services:
       environment:
         - RABBITMQ_DEFAULT_USER=rabbitmq
         - RABBITMQ_DEFAULT_PASS=rabbitmq
-
+        - RABBITMQ_SERVER_ADDITIONAL_ERL_ARGS=-rabbitmq deprecated_features.permit.transient_nonexcl_queues true
+      volumes:
+        - ./rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
 volumes:
     arches-log:
     arches-static:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,7 +220,7 @@ services:
     db:
       # NOTE: due to a race condition, this needs docker-compose run db first to ensure
       # template directory created
-      image: postgis/postgis:14-3.2
+      image: ghcr.io/flaxandteal/arches-postgis:docker-8.1
       volumes:
           - postgres-data:/var/lib/postgresql/data
           - postgres-log:/var/log/postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
         - PGPASSWORD=postgres
         - PGDBNAME=arches2
         - CASBIN_RELOAD_QUEUE=True
+        - CASBIN_LISTEN=True
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -187,6 +188,7 @@ services:
         - DJANGO_MODE=DEV
         - DJANGO_DEBUG=True
         - CASBIN_RELOAD_QUEUE=True
+        - CASBIN_LISTEN=True
         # - DJANGO_REMOTE_DEBUG=False
         - DOMAIN_NAMES=localhost
         - PYTHONUNBUFFERED=0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,9 +208,9 @@ services:
     db:
       # NOTE: due to a race condition, this needs docker-compose run db first to ensure
       # template directory created
-      image: kartoza/postgis:12.0
+      image: postgis/postgis:14-3.2
       volumes:
-          - postgres-data:/var/lib/postgresql
+          - postgres-data:/var/lib/postgresql/data
           - postgres-log:/var/log/postgresql
           - ${ARCHES_PROJECT_ROOT}./docker/init-unix.sql:/docker-entrypoint-initdb.d/init.sql # to set up the DB template
       ports:
@@ -219,16 +219,12 @@ services:
         - '5432'
       environment:
         - POSTGRES_USER=postgres
-        - POSTGRES_PASS=postgres
-        - POSTGRESQL_USER=postgres
-        - POSTGRESQL_PASS=postgres
+        - POSTGRES_PASSWORD=postgres
         - POSTGRES_DB=postgres
-        - POSTGRES_MULTIPLE_EXTENSIONS=postgis,postgis_topology
-        - SHARED_PRELOAD_LIBRARIES=pg_stat_statements
         - TZ=PST
 
     elasticsearch:
-      image: elasticsearch:8.4.0
+      image: elasticsearch:9.0.4
       volumes:
         - elasticsearch-data:/usr/share/elasticsearch/data
       ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
-        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
-        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
@@ -119,8 +117,6 @@ services:
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
-        # ${ARCHES_PROJECT_ROOT}./../arches-for-science/arches_for_science:/web_root/ENV/lib/python3.12/site-packages/arches_for_science
-        # ${ARCHES_PROJECT_ROOT}./../arches-her/arches_her:/web_root/ENV/lib/python3.12/site-packages/arches_her
         #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.12/site-packages/graphql
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches2
+        - PGDBNAME=arches
         - CASBIN_RELOAD_QUEUE=True
         - CASBIN_LISTEN=True
         - PGHOST=db
@@ -81,7 +81,7 @@ services:
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches2
+        - PGDBNAME=arches
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -129,7 +129,7 @@ services:
         - GUNICORN_WORKER_TIMEOUT=300
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches2
+        - PGDBNAME=arches
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -173,14 +173,14 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
+        # - ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.10/site-packages/arches_orm
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False
         - INSTALL_DEFAULT_CONCEPTS=False
         - PGUSERNAME=postgres
         - PGPASSWORD=postgres
-        - PGDBNAME=arches2
+        - PGDBNAME=arches
         - PGHOST=db
         - PGPORT=5432
         - ESHOST=elasticsearch
@@ -210,8 +210,8 @@ services:
       # template directory created
       image: kartoza/postgis:12.0
       volumes:
-          - postgres2-data:/var/lib/postgresql
-          - postgres2-log:/var/log/postgresql
+          - postgres-data:/var/lib/postgresql
+          - postgres-log:/var/log/postgresql
           - ${ARCHES_PROJECT_ROOT}./docker/init-unix.sql:/docker-entrypoint-initdb.d/init.sql # to set up the DB template
       ports:
         - '5432:5432'
@@ -250,7 +250,7 @@ services:
 volumes:
     arches-log:
     arches-static:
-    postgres2-log:
-    postgres2-data:
+    postgres-log:
+    postgres-data:
     elasticsearch-data:
     cantaloupe-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,9 +60,10 @@ services:
         - CANTALOUPE_PORT=8182
         - COMPRESS_ENABLED=False
         - WEB_ROOT=/web_root
+        - WEBPACK_DEVELOPMENT_SERVER_PORT=9000
 
       ports:
-        - '8000:8000'
+      - '8000:8000'
       depends_on:
         - db
         - elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
     cantaloupe:
       image: uclalibrary/cantaloupe:5.0.3-0
@@ -25,7 +24,7 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
+        - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
       environment:
@@ -111,7 +110,7 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
+        - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
         # ${ARCHES_PROJECT_ROOT}./../arches-orm/arches_orm:/web_root/ENV/lib/python3.12/site-packages/arches_orm
         # ${ARCHES_PROJECT_ROOT}./../arches_doorstep/arches_doorstep:/web_root/ENV/lib/python3.12/site-packages/arches_doorstep
         #- ${ARCHES_PROJECT_ROOT}./../.env/lib/python3.11/site-packages/graphql:/web_root/ENV/lib/python3.12/site-packages/graphql
@@ -164,7 +163,7 @@ services:
         - ${ARCHES_PROJECT_ROOT}.:/web_root/$ARCHES_PROJECT
         - ${ARCHES_PROJECT_ROOT}./docker/entrypoint.sh:/web_root/entrypoint.sh
         - ${ARCHES_PROJECT_ROOT}./docker/settings_docker.py:/web_root/$ARCHES_PROJECT/$ARCHES_PROJECT/settings_local.py
-        - ${ARCHES_PROJECT_ROOT}/arches_apps:/web_root/arches_apps
+        - ${ARCHES_PROJECT_ROOT}./../arches_apps:/web_root/arches_apps
       environment:
         - ARCHES_PROJECT=$ARCHES_PROJECT
         - INSTALL_DEFAULT_GRAPHS=False

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,7 +30,7 @@ fi
 # Read modules folder from npm config file
 # Get string after '--install.modules-folder' -> get first word of the result 
 # -> remove line endlings -> trim quotes -> trim leading ./
-NPM_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/media/node_modules
+NPM_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/node_modules
 
 export DJANGO_PORT=${DJANGO_PORT:-8000}
 STATIC_ROOT=${STATIC_ROOT:-/static_root}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -264,7 +264,7 @@ run_npm_build_production() {
 	cd_app_folder
 	sleep 10
 	cd ${ARCHES_PROJECT}
-	npm build_production
+	npm run build_production
 }
 
 run_npm_build_development() {
@@ -275,7 +275,7 @@ run_npm_build_development() {
 	cd_app_folder
 	sleep 10
 	cd ${ARCHES_PROJECT}
-	npm build_development
+	npm run build_development
 }
 
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -247,7 +247,7 @@ run_npm_start() {
 	echo ""
 	cd_app_folder
 	sleep 10
-	cd ${ARCHES_PROJECT}
+	# cd ${ARCHES_PROJECT}
 	npm start
 }
 
@@ -258,7 +258,7 @@ run_npm_build_production() {
 	echo ""
 	cd_app_folder
 	sleep 10
-	cd ${ARCHES_PROJECT}
+	# cd ${ARCHES_PROJECT}
 	npm run build_production
 }
 
@@ -269,7 +269,7 @@ run_npm_build_development() {
 	echo ""
 	cd_app_folder
 	sleep 10
-	cd ${ARCHES_PROJECT}
+	# cd ${ARCHES_PROJECT}
 	npm run build_development
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -30,12 +30,7 @@ fi
 # Read modules folder from npm config file
 # Get string after '--install.modules-folder' -> get first word of the result 
 # -> remove line endlings -> trim quotes -> trim leading ./
-NPM_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/$(awk \
-	-F '--install.modules-folder' '{print $2}' ${PACKAGE_JSON_FOLDER} \
-	| awk '{print $1}' \
-	| tr -d $'\r' \
-	| tr -d '"' \
-	| sed -e "s/^\.\///g")
+NPM_MODULES_FOLDER=${PACKAGE_JSON_FOLDER}/media/node_modules
 
 export DJANGO_PORT=${DJANGO_PORT:-8000}
 STATIC_ROOT=${STATIC_ROOT:-/static_root}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,7 +24,7 @@ else
 	# due to https://github.com/archesproject/arches/issues/4841, changes were made to npm install
 	# and module deployment. Using the arches install directory for npm.
 	# PTW PACKAGE_JSON_FOLDER=${ARCHES_ROOT}/arches/install
-	PACKAGE_JSON_FOLDER=${WEB_ROOT}/${ARCHES_PROJECT}/${ARCHES_PROJECT}
+	PACKAGE_JSON_FOLDER=${WEB_ROOT}/${ARCHES_PROJECT}
 fi
 
 # Read modules folder from npm config file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -472,7 +472,7 @@ install_arches_apps() {
 	# Ensure the expected directory exists (mounted by docker-compose)
 	if [[ ! -d "${ARCHES_APPS_DIR}" ]]; then
 		echo "No arches_app directory found, mounted apps will not be installed"
-		exit 1
+		return 0
 	fi
 
 	# If directory exists but is empty, warn and skip installation.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -514,7 +514,7 @@ run_tests() {
 	echo "----- RUNNING ARCHES TESTS -----"
 	echo ""
 	cd_arches_root
-	python manage.py test tests --pattern="*.py" --settings="quartz.test_settings" --exe
+	PYTHONPATH=. python manage.py test tests --pattern="*.py" --settings="quartz.test.test_settings" --exe
 	if [ $? -ne 0 ]; then
         echo "Error: Not all tests ran succesfully."
 		echo "Exiting..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,10 +98,6 @@ bootstrap() {
 # Setup Postgresql and Elasticsearch
 setup_arches() {
 
-	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
-		install_arches_apps
-	fi
-
 	cd_arches_root
 
 	echo "" && echo ""
@@ -157,25 +153,25 @@ setup_arches() {
 }
 
 wait_for_db() {
-	echo "Testing if database server is up..."
-	return_code=1
-	while [[ ! ${return_code} == 0 ]]
-	do
-        psql --host=${PGHOST} --port=${PGPORT} --user=${PGUSERNAME} --dbname=postgres -c "select 1" >&/dev/null
-		return_code=$?
-		sleep 1
-	done
-	echo "Database server is up"
+	echo "Waiting for database and Elasticsearch..."
 
-    echo "Testing if Elasticsearch is up..."
-    es_return_code=1
-    while [[ ! ${es_return_code} == 0 ]]
-    do
-        curl -s "http://${ESHOST}:${ESPORT}/_cluster/health?wait_for_status=yellow&timeout=60s" >&/dev/null
-        es_return_code=$?
-        sleep 1
-    done
-    echo "Elasticsearch is up"
+	# Poll both services in parallel
+	(
+		while ! psql --host=${PGHOST} --port=${PGPORT} --user=${PGUSERNAME} --dbname=postgres -c "select 1" &>/dev/null; do
+			sleep 1
+		done
+		echo "Database server is up"
+	) &
+
+	(
+		while ! curl -sf "http://${ESHOST}:${ESPORT}/_cluster/health?wait_for_status=yellow&timeout=60s" &>/dev/null; do
+			sleep 1
+		done
+		echo "Elasticsearch is up"
+	) &
+
+	wait
+	echo "All services are ready"
 }
 
 db_exists() {
@@ -262,8 +258,6 @@ run_npm_start() {
 	echo "----- RUNNING NPM SERVER -----"
 	echo ""
 	cd_app_folder
-	sleep 10
-	# cd ${ARCHES_PROJECT}
 	npm start
 }
 
@@ -273,8 +267,6 @@ run_npm_build_production() {
 	echo "----- RUNNING NPM BUILD PRODUCTION -----"
 	echo ""
 	cd_app_folder
-	sleep 10
-	# cd ${ARCHES_PROJECT}
 	npm run build_production
 }
 
@@ -284,8 +276,6 @@ run_npm_build_development() {
 	echo "----- RUNNING NPM BUILD DEVELOPMENT -----"
 	echo ""
 	cd_app_folder
-	sleep 10
-	# cd ${ARCHES_PROJECT}
 	npm run build_development
 }
 
@@ -500,7 +490,6 @@ run_arches() {
 	init_npm_components
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
-		set_dev_mode
 		if [[ "${USE_LOCAL_APPS}" == "true" ]]; then
 			install_arches_apps
 		fi
@@ -525,7 +514,7 @@ run_tests() {
 	echo "----- RUNNING ARCHES TESTS -----"
 	echo ""
 	cd_arches_root
-	python manage.py test tests --pattern="*.py" --settings="tests.test_settings" --exe
+	python manage.py test tests --pattern="*.py" --settings="quartz.test_settings" --exe
 	if [ $? -ne 0 ]; then
         echo "Error: Not all tests ran succesfully."
 		echo "Exiting..."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -501,7 +501,9 @@ run_arches() {
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
 		set_dev_mode
-		install_arches_apps
+		if [[ "${USE_LOCAL_APPS}" == "true" ]]; then
+			install_arches_apps
+		fi
 	fi
 
 	run_custom_scripts

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -153,6 +153,7 @@ setup_arches() {
 
 wait_for_db() {
 	echo "Testing if database server is up..."
+	return_code=1
 	while [[ ! ${return_code} == 0 ]]
 	do
         psql --host=${PGHOST} --port=${PGPORT} --user=${PGUSERNAME} --dbname=postgres -c "select 1" >&/dev/null
@@ -162,10 +163,11 @@ wait_for_db() {
 	echo "Database server is up"
 
     echo "Testing if Elasticsearch is up..."
-    while [[ ! ${return_code} == 0 ]]
+    es_return_code=1
+    while [[ ! ${es_return_code} == 0 ]]
     do
-        curl -s "http://${ESHOST}:${ESPORT}/_cluster/health?wait_for_status=green&timeout=60s" >&/dev/null
-        return_code=$?
+        curl -s "http://${ESHOST}:${ESPORT}/_cluster/health?wait_for_status=yellow&timeout=60s" >&/dev/null
+        es_return_code=$?
         sleep 1
     done
     echo "Elasticsearch is up"
@@ -243,7 +245,7 @@ run_graphql_server() {
 run_npm_start() {
 	echo ""
 	echo ""
-	echo "----- RUNNING YARN SERVER -----"
+	echo "----- RUNNING NPM SERVER -----"
 	echo ""
 	cd_app_folder
 	sleep 10
@@ -254,7 +256,7 @@ run_npm_start() {
 run_npm_build_production() {
 	echo ""
 	echo ""
-	echo "----- RUNNING YARN SERVER -----"
+	echo "----- RUNNING NPM BUILD PRODUCTION -----"
 	echo ""
 	cd_app_folder
 	sleep 10
@@ -265,7 +267,7 @@ run_npm_build_production() {
 run_npm_build_development() {
 	echo ""
 	echo ""
-	echo "----- RUNNING YARN SERVER -----"
+	echo "----- RUNNING NPM BUILD DEVELOPMENT -----"
 	echo ""
 	cd_app_folder
 	sleep 10

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -221,6 +221,13 @@ install_npm_components() {
 	echo ""
 	cd_npm_folder
 	npm install
+	# Verify lodash isn't truncated (intermittent tar extraction issue under buildkit overlay fs)
+	if [ -d node_modules/lodash ] && [ ! -f node_modules/lodash/_baseSortedIndex.js ]; then
+		echo "lodash appears truncated, reinstalling..."
+		rm -rf node_modules/lodash
+		npm cache clean --force || true
+		npm install
+	fi
 }
 
 update_npm_components() {
@@ -431,7 +438,7 @@ run_api_server() {
 	cd_app_folder
 
 	if [[ ! -z ${ARCHES_PROJECT} ]]; then
-        DJANGO_SETTINGS_MODULE=${ARCHES_PROJECT}.settings gunicorn arches_orm.graphql.django_asgi:app \
+        DJANGO_SETTINGS_MODULE=${ARCHES_PROJECT}.settings gunicorn ${ARCHES_PROJECT}.asgi:application \
             --config ${ARCHES_ROOT}/docker/gunicorn_config.py \
 	    -k uvicorn.workers.UvicornWorker
 	fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -222,6 +222,15 @@ install_npm_components() {
 	npm install
 }
 
+update_npm_components() {
+	echo ""
+	echo ""
+	echo "----- UPDATING NPM COMPONENTS -----"
+	echo ""
+	cd_npm_folder
+	npm update
+}
+
 #### Main commands
 run_arches_graphql() {
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -97,6 +97,11 @@ bootstrap() {
 
 # Setup Postgresql and Elasticsearch
 setup_arches() {
+
+	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
+		install_arches_apps
+	fi
+
 	cd_arches_root
 
 	echo "" && echo ""
@@ -459,7 +464,33 @@ run_gunicorn_server() {
     fi
 }
 
+install_arches_apps() {
+	echo "Installing local apps in editable mode..."
 
+	ARCHES_APPS_DIR="${WEB_ROOT}/arches_apps"
+
+	# Ensure the expected directory exists (mounted by docker-compose)
+	if [[ ! -d "${ARCHES_APPS_DIR}" ]]; then
+		echo "No arches_app directory found, mounted apps will not be installed"
+		exit 1
+	fi
+
+	# If directory exists but is empty, warn and skip installation.
+	shopt -s nullglob
+	apps=("${ARCHES_APPS_DIR}"/*)
+	shopt -u nullglob
+	if [[ ${#apps[@]} -eq 0 ]]; then
+		echo "Warning: '${ARCHES_APPS_DIR}' is empty — nothing to install."
+		return 0
+	fi
+
+	for d in "${ARCHES_APPS_DIR}"/*; do
+		if [[ -d "$d" ]]; then
+			pip install -e "$d" || true
+			echo "Installed $d"
+		fi
+	done
+}
 
 #### Main commands
 run_arches() {
@@ -470,6 +501,7 @@ run_arches() {
 
 	if [[ "${DJANGO_MODE}" == "DEV" ]]; then
 		set_dev_mode
+		install_arches_apps
 	fi
 
 	run_custom_scripts
@@ -559,6 +591,9 @@ do
 		;;
 		install_npm_components)
 			install_npm_components
+		;;
+		install_arches_apps)
+			install_arches_apps
 		;;
 		run_npm_build_development)
 			run_npm_build_development

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -486,7 +486,7 @@ install_arches_apps() {
 
 	for d in "${ARCHES_APPS_DIR}"/*; do
 		if [[ -d "$d" ]]; then
-			pip install -e "$d" || true
+			pip install --no-deps -e "$d" || pip install -e "$d" || true
 			echo "Installed $d"
 		fi
 	done

--- a/init-unix.sql
+++ b/init-unix.sql
@@ -1,7 +1,7 @@
 -- Largely copied from the AGPL-3.0 Arches project
 -- https://github.com/archesproject/arches
 
-CREATE DATABASE template_postgis WITH ENCODING 'UTF8' LC_COLLATE='C.UTF-8' LC_CTYPE='C.UTF-8';
+CREATE DATABASE template_postgis WITH ENCODING 'UTF8' LC_COLLATE='en_US.utf8' LC_CTYPE='en_US.utf8';
 UPDATE pg_database SET datistemplate='true' WHERE datname='template_postgis';
 
 \c template_postgis

--- a/init-unix.sql
+++ b/init-unix.sql
@@ -1,7 +1,9 @@
 -- Largely copied from the AGPL-3.0 Arches project
 -- https://github.com/archesproject/arches
 
-CREATE DATABASE template_postgis WITH ENCODING 'UTF8' LC_COLLATE='en_US.utf8' LC_CTYPE='en_US.utf8';
+SELECT 'CREATE DATABASE template_postgis WITH ENCODING ''UTF8'' LC_COLLATE=''en_US.utf8'' LC_CTYPE=''en_US.utf8'''
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'template_postgis')\gexec
+
 UPDATE pg_database SET datistemplate='true' WHERE datname='template_postgis';
 
 \c template_postgis

--- a/install_app.py
+++ b/install_app.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""
+Script to install an Arches app from a GitHub repository.
+This script clones the repository, extracts package information from pyproject.toml,
+and updates the project's settings.py, pyproject.toml, and urls.py files.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def run_command(cmd, cwd=None):
+    """Run a shell command and return the result."""
+    try:
+        result = subprocess.run(cmd, shell=True, cwd=cwd, capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"Error running command '{cmd}': {e}")
+        print(f"stderr: {e.stderr}")
+        sys.exit(1)
+
+
+def extract_repo_name(url):
+    """Extract repository name from GitHub URL."""
+    if url.endswith('.git'):
+        url = url[:-4]
+    return os.path.basename(url)
+
+
+def create_apps_dir(apps_dir):
+    """Create the arches_apps directory if it doesn't exist."""
+    if not os.path.exists(apps_dir):
+        os.makedirs(apps_dir)
+        print(f"Created {apps_dir} directory")
+    else:
+        print(f"{apps_dir} already exists")
+
+
+def clone_repository(url, target_dir):
+    """Clone the repository to the target directory."""
+    if os.path.exists(target_dir):
+        print(f"Repository already exists at {target_dir}, exiting...")
+        sys.exit(0)
+        
+    print(f"Cloning repository into {target_dir}")
+    run_command(f"git clone {url} {target_dir}")
+    print(f"Cloned repository into {target_dir}")
+
+
+def parse_pyproject_toml(repo_dir):
+    """Parse pyproject.toml and extract package name and optional dependencies."""
+    pyproject_path = os.path.join(repo_dir, 'pyproject.toml')
+    
+    if not os.path.exists(pyproject_path):
+        print(f"Error: pyproject.toml not found in {repo_dir}")
+        sys.exit(1)
+    
+    try:
+        with open(pyproject_path, 'r') as f:
+            content = f.read()
+        
+        # Extract package name
+        name_match = re.search(r'^name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+        if not name_match:
+            print("Error: Could not extract package name from pyproject.toml")
+            sys.exit(1)
+        
+        package_name = name_match.group(1).replace('-', '_')
+        
+        # Extract optional dependencies keys
+        optional_deps_keys = []
+        optional_deps_section = re.search(r'\[project\.optional-dependencies\](.*?)(?=\n\[|\n\n|\Z)', content, re.DOTALL)
+        if optional_deps_section:
+            deps_content = optional_deps_section.group(1)
+            # Find all keys in the optional dependencies section
+            key_matches = re.findall(r'^([a-zA-Z0-9_-]+)\s*=', deps_content, re.MULTILINE)
+            optional_deps_keys = key_matches
+        
+        return package_name, optional_deps_keys
+    except Exception as e:
+        print(f"Error parsing pyproject.toml: {e}")
+        sys.exit(1)
+
+
+def update_installed_apps(settings_path, cloned_settings_path, package_name):
+    """Update INSTALLED_APPS in the project settings.py by adding missing dependencies from cloned repo."""
+    if not os.path.exists(settings_path):
+        print(f"Error: settings.py not found at {settings_path}")
+        return
+    
+    # Read project settings
+    with open(settings_path, 'r') as f:
+        content = f.read()
+    
+    # Extract INSTALLED_APPS from cloned repo if it exists
+    cloned_apps = set()
+    if os.path.exists(cloned_settings_path):
+        with open(cloned_settings_path, 'r') as f:
+            cloned_content = f.read()
+        
+        # Find INSTALLED_APPS = (...) with balanced parentheses
+        lines = cloned_content.split('\n')
+        in_installed_apps = False
+        paren_count = 0
+        
+        for line in lines:
+            if 'INSTALLED_APPS' in line and '=' in line and '+=' not in line:
+                in_installed_apps = True
+                # Count opening parens/brackets in this line
+                paren_count += line.count('(') + line.count('[')
+                paren_count -= line.count(')') + line.count(']')
+                
+                # Extract apps from this line (skip if commented out)
+                if not line.strip().startswith('#'):
+                    app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                    cloned_apps.update(app.strip() for app in app_matches if app.strip())
+                
+                if paren_count == 0:
+                    break
+            elif in_installed_apps:
+                # Count parens/brackets
+                paren_count += line.count('(') + line.count('[')
+                paren_count -= line.count(')') + line.count(']')
+                
+                # Extract apps from this line (skip if commented out)
+                if not line.strip().startswith('#'):
+                    app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                    cloned_apps.update(app.strip() for app in app_matches if app.strip())
+                
+                if paren_count == 0:
+                    break
+    
+    # Always add the main package
+    cloned_apps.add(package_name)
+    
+    # Extract current INSTALLED_APPS from project (both = and += sections)
+    current_apps = set()
+    lines = content.split('\n')
+    
+    # Parse INSTALLED_APPS = (...) section
+    in_main_apps = False
+    paren_count = 0
+    for line in lines:
+        if 'INSTALLED_APPS' in line and '=' in line and '+=' not in line:
+            in_main_apps = True
+            paren_count += line.count('(') + line.count('[')
+            paren_count -= line.count(')') + line.count(']')
+            
+            # Extract apps from this line (skip if commented out)
+            if not line.strip().startswith('#'):
+                app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                current_apps.update(app.strip() for app in app_matches if app.strip())
+            
+            if paren_count == 0:
+                break
+        elif in_main_apps:
+            paren_count += line.count('(') + line.count('[')
+            paren_count -= line.count(')') + line.count(']')
+            
+            # Extract apps from this line (skip if commented out)
+            if not line.strip().startswith('#'):
+                app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                current_apps.update(app.strip() for app in app_matches if app.strip())
+            
+            if paren_count == 0:
+                break
+    
+    # Parse INSTALLED_APPS += (...) section
+    in_plus_apps = False
+    paren_count = 0
+    for line in lines:
+        if 'INSTALLED_APPS' in line and '+=' in line:
+            in_plus_apps = True
+            paren_count += line.count('(') + line.count('[')
+            paren_count -= line.count(')') + line.count(']')
+            
+            # Extract apps from this line (skip if commented out)
+            if not line.strip().startswith('#'):
+                app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                current_apps.update(app.strip() for app in app_matches if app.strip())
+            
+            if paren_count == 0:
+                break
+        elif in_plus_apps:
+            paren_count += line.count('(') + line.count('[')
+            paren_count -= line.count(')') + line.count(']')
+            
+            # Extract apps from this line (skip if commented out)
+            if not line.strip().startswith('#'):
+                app_matches = re.findall(r'["\']([^"\']+)["\']', line)
+                current_apps.update(app.strip() for app in app_matches if app.strip())
+            
+            if paren_count == 0:
+                break
+    
+    # Find missing apps that need to be added
+    missing_apps = cloned_apps - current_apps
+    
+    if not missing_apps:
+        print(f"All required apps are already installed (including {package_name})")
+        return
+    
+    print(f"Adding missing apps: {', '.join(sorted(missing_apps))}")
+    
+    # Find the INSTALLED_APPS += section and add missing apps
+    plus_start_idx = None
+    plus_end_idx = None
+    
+    for i, line in enumerate(lines):
+        if 'INSTALLED_APPS' in line and '+=' in line:
+            plus_start_idx = i
+            paren_count = line.count('(') + line.count('[') - line.count(')') - line.count(']')
+            
+            if paren_count == 0:
+                plus_end_idx = i
+                break
+            else:
+                # Find the closing paren/bracket
+                for j in range(i + 1, len(lines)):
+                    paren_count += lines[j].count('(') + lines[j].count('[')
+                    paren_count -= lines[j].count(')') + lines[j].count(']')
+                    if paren_count == 0:
+                        plus_end_idx = j
+                        break
+            break
+    
+    if plus_start_idx is not None and plus_end_idx is not None:
+        # Insert missing apps before the closing parenthesis
+        new_lines = lines[:plus_end_idx]
+        for app in sorted(missing_apps):
+            new_lines.append(f'    "{app}",')
+        new_lines.extend(lines[plus_end_idx:])
+        
+        # Write back to file
+        with open(settings_path, 'w') as f:
+            f.write('\n'.join(new_lines))
+        
+        print(f"Added {len(missing_apps)} apps to INSTALLED_APPS += section in {settings_path}")
+    else:
+        print("Warning: Could not find INSTALLED_APPS += section to add missing apps")
+
+
+def update_pyproject_dependencies(pyproject_path, package_name, optional_deps_keys):
+    """Update dependencies in the project pyproject.toml."""
+    if not os.path.exists(pyproject_path):
+        print(f"Error: pyproject.toml not found at {pyproject_path}")
+        return
+    
+    try:
+        with open(pyproject_path, 'r') as f:
+            content = f.read()
+        
+        # Find the dependencies section
+        deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
+        if not deps_match:
+            print("Error: Could not find dependencies section in pyproject.toml")
+            return
+        
+        current_deps_text = deps_match.group(1)
+        
+        # Create dependency string
+        if optional_deps_keys:
+            # Use the first optional dependency key
+            dep_string = f"{package_name}[{optional_deps_keys[0]}]"
+        else:
+            dep_string = package_name
+        
+        # Check if already in dependencies
+        if dep_string in current_deps_text or package_name in current_deps_text:
+            print(f"{dep_string} already in dependencies")
+            return
+        
+        # Parse existing dependencies to properly format
+        if current_deps_text.strip():
+            # Split into lines and clean up
+            lines = current_deps_text.split('\n')
+            existing_deps = []
+            
+            for line in lines:
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    # Remove trailing comma and quotes, extract dependency name
+                    dep_line = line.rstrip(',').strip()
+                    if dep_line.startswith('"') and dep_line.endswith('"'):
+                        existing_deps.append(dep_line)
+                    elif dep_line.startswith("'") and dep_line.endswith("'"):
+                        existing_deps.append(dep_line)
+                    elif dep_line and not dep_line.startswith('#'):
+                        # Add quotes if missing
+                        existing_deps.append(f'"{dep_line}"')
+            
+            # Add the new dependency
+            existing_deps.append(f'"{dep_string}"')
+            
+            # Format with proper indentation and commas
+            new_deps_text = '\n    ' + ',\n    '.join(existing_deps) + '\n'
+        else:
+            # No existing dependencies
+            new_deps_text = f'\n    "{dep_string}"\n'
+        
+        new_dependencies = f"dependencies = [{new_deps_text}]"
+        new_content = re.sub(r'dependencies\s*=\s*\[.*?\]', new_dependencies, content, flags=re.DOTALL)
+        
+        with open(pyproject_path, 'w') as f:
+            f.write(new_content)
+        
+        print(f"Added {dep_string} to dependencies in {pyproject_path}")
+    
+    except Exception as e:
+        print(f"Error updating pyproject.toml: {e}")
+
+
+def update_urls_py(urls_path, package_name):
+    """Update urls.py to include the new package URLs."""
+    if not os.path.exists(urls_path):
+        print(f"Error: urls.py not found at {urls_path}")
+        return
+    
+    with open(urls_path, 'r') as f:
+        content = f.read()
+    
+    # Check if the URL pattern already exists
+    url_pattern = f"urlpatterns.append(path('', include('{package_name}.urls')))"
+    if url_pattern in content:
+        print(f"URL pattern for {package_name} already exists in urls.py")
+        return
+    
+    # Find the line with arches.urls and add after it
+    arches_pattern = r"urlpatterns\.append\(path\('', include\('arches\.urls'\)\)\)"
+    if re.search(arches_pattern, content):
+        new_content = re.sub(
+            arches_pattern,
+            f"urlpatterns.append(path('', include('arches.urls')))\n{url_pattern}",
+            content
+        )
+        
+        with open(urls_path, 'w') as f:
+            f.write(new_content)
+        
+        print(f"Added URL pattern for {package_name} to {urls_path}")
+    else:
+        print("Could not find arches.urls pattern in urls.py")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Install an Arches app from a GitHub repository')
+    parser.add_argument('url', help='GitHub repository URL')
+    parser.add_argument('--project-root', default='.', help='Project root directory')
+    
+    args = parser.parse_args()
+    
+    # Determine project structure
+    project_root = os.path.abspath(args.project_root)
+    apps_dir = os.path.join(os.path.dirname(project_root), 'arches_apps')
+    
+    # Find the Arches project directory (contains __init__.py)
+    project_dirs = [d for d in os.listdir(project_root) 
+                   if os.path.isdir(os.path.join(project_root, d)) and 
+                   os.path.exists(os.path.join(project_root, d, '__init__.py'))]
+    
+    if not project_dirs:
+        print("Error: Could not find Arches project directory (no directory with __init__.py found)")
+        sys.exit(1)
+    
+    arches_project = project_dirs[0]
+    
+    # Extract repository name
+    repo_name = extract_repo_name(args.url)
+    repo_dir = os.path.join(apps_dir, repo_name)
+    
+    # Create apps directory
+    create_apps_dir(apps_dir)
+    
+    # Clone repository
+    clone_repository(args.url, repo_dir)
+    
+    # Parse pyproject.toml
+    package_name, optional_deps_keys = parse_pyproject_toml(repo_dir)
+    
+    # Update project files
+    settings_path = os.path.join(project_root, arches_project, 'settings.py')
+    cloned_settings_path = os.path.join(repo_dir, package_name, 'settings.py')
+    pyproject_path = os.path.join(project_root, 'pyproject.toml')
+    urls_path = os.path.join(project_root, arches_project, 'urls.py')
+    
+    update_installed_apps(settings_path, cloned_settings_path, package_name)
+    update_pyproject_dependencies(pyproject_path, package_name, optional_deps_keys)
+    update_urls_py(urls_path, package_name)
+    
+    print(f"Successfully installed {package_name} from {args.url}")
+
+
+if __name__ == '__main__':
+    main()

--- a/install_app.py
+++ b/install_app.py
@@ -39,14 +39,15 @@ def create_apps_dir(apps_dir):
         print(f"{apps_dir} already exists")
 
 
-def clone_repository(url, target_dir):
+def clone_repository(url, target_dir, branch=None):
     """Clone the repository to the target directory."""
     if os.path.exists(target_dir):
         print(f"Repository already exists at {target_dir}, exiting...")
         sys.exit(0)
-        
-    print(f"Cloning repository into {target_dir}")
-    run_command(f"git clone {url} {target_dir}")
+
+    branch_flag = f" --branch {branch}" if branch else ""
+    print(f"Cloning repository into {target_dir}" + (f" (branch: {branch})" if branch else ""))
+    run_command(f"git clone{branch_flag} {url} {target_dir}")
     print(f"Cloned repository into {target_dir}")
 
 
@@ -348,6 +349,7 @@ def update_urls_py(urls_path, package_name):
 def main():
     parser = argparse.ArgumentParser(description='Install an Arches app from a GitHub repository')
     parser.add_argument('url', help='GitHub repository URL')
+    parser.add_argument('--branch', '-b', default=None, help='Git branch to clone')
     parser.add_argument('--project-root', default='.', help='Project root directory')
     
     args = parser.parse_args()
@@ -375,7 +377,7 @@ def main():
     create_apps_dir(apps_dir)
     
     # Clone repository
-    clone_repository(args.url, repo_dir)
+    clone_repository(args.url, repo_dir, args.branch)
     
     # Parse pyproject.toml
     package_name, optional_deps_keys = parse_pyproject_toml(repo_dir)

--- a/install_app.py
+++ b/install_app.py
@@ -15,7 +15,9 @@ import sys
 def run_command(cmd, cwd=None):
     """Run a shell command and return the result."""
     try:
-        result = subprocess.run(cmd, shell=True, cwd=cwd, capture_output=True, text=True, check=True)
+        result = subprocess.run(
+            cmd, shell=True, cwd=cwd, capture_output=True, text=True, check=True
+        )
         return result.stdout.strip()
     except subprocess.CalledProcessError as e:
         print(f"Error running command '{cmd}': {e}")
@@ -25,7 +27,7 @@ def run_command(cmd, cwd=None):
 
 def extract_repo_name(url):
     """Extract repository name from GitHub URL."""
-    if url.endswith('.git'):
+    if url.endswith(".git"):
         url = url[:-4]
     return os.path.basename(url)
 
@@ -46,40 +48,51 @@ def clone_repository(url, target_dir, branch=None):
         sys.exit(0)
 
     branch_flag = f" --branch {branch}" if branch else ""
-    print(f"Cloning repository into {target_dir}" + (f" (branch: {branch})" if branch else ""))
+    print(
+        f"Cloning repository into {target_dir}"
+        + (f" (branch: {branch})" if branch else "")
+    )
     run_command(f"git clone{branch_flag} {url} {target_dir}")
     print(f"Cloned repository into {target_dir}")
 
 
 def parse_pyproject_toml(repo_dir):
     """Parse pyproject.toml and extract package name and optional dependencies."""
-    pyproject_path = os.path.join(repo_dir, 'pyproject.toml')
-    
+    pyproject_path = os.path.join(repo_dir, "pyproject.toml")
+
     if not os.path.exists(pyproject_path):
         print(f"Error: pyproject.toml not found in {repo_dir}")
         sys.exit(1)
-    
+
     try:
-        with open(pyproject_path, 'r') as f:
+        with open(pyproject_path, "r") as f:
             content = f.read()
-        
+
         # Extract package name
-        name_match = re.search(r'^name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE)
+        name_match = re.search(
+            r'^name\s*=\s*["\']([^"\']+)["\']', content, re.MULTILINE
+        )
         if not name_match:
             print("Error: Could not extract package name from pyproject.toml")
             sys.exit(1)
-        
-        package_name = name_match.group(1).replace('-', '_')
-        
+
+        package_name = name_match.group(1).replace("-", "_")
+
         # Extract optional dependencies keys
         optional_deps_keys = []
-        optional_deps_section = re.search(r'\[project\.optional-dependencies\](.*?)(?=\n\[|\n\n|\Z)', content, re.DOTALL)
+        optional_deps_section = re.search(
+            r"\[project\.optional-dependencies\](.*?)(?=\n\[|\n\n|\Z)",
+            content,
+            re.DOTALL,
+        )
         if optional_deps_section:
             deps_content = optional_deps_section.group(1)
             # Find all keys in the optional dependencies section
-            key_matches = re.findall(r'^([a-zA-Z0-9_-]+)\s*=', deps_content, re.MULTILINE)
+            key_matches = re.findall(
+                r"^([a-zA-Z0-9_-]+)\s*=", deps_content, re.MULTILINE
+            )
             optional_deps_keys = key_matches
-        
+
         return package_name, optional_deps_keys
     except Exception as e:
         print(f"Error parsing pyproject.toml: {e}")
@@ -91,155 +104,163 @@ def update_installed_apps(settings_path, cloned_settings_path, package_name):
     if not os.path.exists(settings_path):
         print(f"Error: settings.py not found at {settings_path}")
         return
-    
+
     # Read project settings
-    with open(settings_path, 'r') as f:
+    with open(settings_path, "r") as f:
         content = f.read()
-    
+
     # Extract INSTALLED_APPS from cloned repo if it exists
     cloned_apps = set()
     if os.path.exists(cloned_settings_path):
-        with open(cloned_settings_path, 'r') as f:
+        with open(cloned_settings_path, "r") as f:
             cloned_content = f.read()
-        
+
         # Find INSTALLED_APPS = (...) with balanced parentheses
-        lines = cloned_content.split('\n')
+        lines = cloned_content.split("\n")
         in_installed_apps = False
         paren_count = 0
-        
+
         for line in lines:
-            if 'INSTALLED_APPS' in line and '=' in line and '+=' not in line:
+            if "INSTALLED_APPS" in line and "=" in line and "+=" not in line:
                 in_installed_apps = True
                 # Count opening parens/brackets in this line
-                paren_count += line.count('(') + line.count('[')
-                paren_count -= line.count(')') + line.count(']')
-                
+                paren_count += line.count("(") + line.count("[")
+                paren_count -= line.count(")") + line.count("]")
+
                 # Extract apps from this line (skip if commented out)
-                if not line.strip().startswith('#'):
+                if not line.strip().startswith("#"):
                     app_matches = re.findall(r'["\']([^"\']+)["\']', line)
-                    cloned_apps.update(app.strip() for app in app_matches if app.strip())
-                
+                    cloned_apps.update(
+                        app.strip() for app in app_matches if app.strip()
+                    )
+
                 if paren_count == 0:
                     break
             elif in_installed_apps:
                 # Count parens/brackets
-                paren_count += line.count('(') + line.count('[')
-                paren_count -= line.count(')') + line.count(']')
-                
+                paren_count += line.count("(") + line.count("[")
+                paren_count -= line.count(")") + line.count("]")
+
                 # Extract apps from this line (skip if commented out)
-                if not line.strip().startswith('#'):
+                if not line.strip().startswith("#"):
                     app_matches = re.findall(r'["\']([^"\']+)["\']', line)
-                    cloned_apps.update(app.strip() for app in app_matches if app.strip())
-                
+                    cloned_apps.update(
+                        app.strip() for app in app_matches if app.strip()
+                    )
+
                 if paren_count == 0:
                     break
-    
+
     # Always add the main package
     cloned_apps.add(package_name)
-    
+
     # Extract current INSTALLED_APPS from project (both = and += sections)
     current_apps = set()
-    lines = content.split('\n')
-    
+    lines = content.split("\n")
+
     # Parse INSTALLED_APPS = (...) section
     in_main_apps = False
     paren_count = 0
     for line in lines:
-        if 'INSTALLED_APPS' in line and '=' in line and '+=' not in line:
+        if "INSTALLED_APPS" in line and "=" in line and "+=" not in line:
             in_main_apps = True
-            paren_count += line.count('(') + line.count('[')
-            paren_count -= line.count(')') + line.count(']')
-            
+            paren_count += line.count("(") + line.count("[")
+            paren_count -= line.count(")") + line.count("]")
+
             # Extract apps from this line (skip if commented out)
-            if not line.strip().startswith('#'):
+            if not line.strip().startswith("#"):
                 app_matches = re.findall(r'["\']([^"\']+)["\']', line)
                 current_apps.update(app.strip() for app in app_matches if app.strip())
-            
+
             if paren_count == 0:
                 break
         elif in_main_apps:
-            paren_count += line.count('(') + line.count('[')
-            paren_count -= line.count(')') + line.count(']')
-            
+            paren_count += line.count("(") + line.count("[")
+            paren_count -= line.count(")") + line.count("]")
+
             # Extract apps from this line (skip if commented out)
-            if not line.strip().startswith('#'):
+            if not line.strip().startswith("#"):
                 app_matches = re.findall(r'["\']([^"\']+)["\']', line)
                 current_apps.update(app.strip() for app in app_matches if app.strip())
-            
+
             if paren_count == 0:
                 break
-    
+
     # Parse INSTALLED_APPS += (...) section
     in_plus_apps = False
     paren_count = 0
     for line in lines:
-        if 'INSTALLED_APPS' in line and '+=' in line:
+        if "INSTALLED_APPS" in line and "+=" in line:
             in_plus_apps = True
-            paren_count += line.count('(') + line.count('[')
-            paren_count -= line.count(')') + line.count(']')
-            
+            paren_count += line.count("(") + line.count("[")
+            paren_count -= line.count(")") + line.count("]")
+
             # Extract apps from this line (skip if commented out)
-            if not line.strip().startswith('#'):
+            if not line.strip().startswith("#"):
                 app_matches = re.findall(r'["\']([^"\']+)["\']', line)
                 current_apps.update(app.strip() for app in app_matches if app.strip())
-            
+
             if paren_count == 0:
                 break
         elif in_plus_apps:
-            paren_count += line.count('(') + line.count('[')
-            paren_count -= line.count(')') + line.count(']')
-            
+            paren_count += line.count("(") + line.count("[")
+            paren_count -= line.count(")") + line.count("]")
+
             # Extract apps from this line (skip if commented out)
-            if not line.strip().startswith('#'):
+            if not line.strip().startswith("#"):
                 app_matches = re.findall(r'["\']([^"\']+)["\']', line)
                 current_apps.update(app.strip() for app in app_matches if app.strip())
-            
+
             if paren_count == 0:
                 break
-    
+
     # Find missing apps that need to be added
     missing_apps = cloned_apps - current_apps
-    
+
     if not missing_apps:
         print(f"All required apps are already installed (including {package_name})")
         return
-    
+
     print(f"Adding missing apps: {', '.join(sorted(missing_apps))}")
-    
+
     # Find the INSTALLED_APPS += section and add missing apps
     plus_start_idx = None
     plus_end_idx = None
-    
+
     for i, line in enumerate(lines):
-        if 'INSTALLED_APPS' in line and '+=' in line:
+        if "INSTALLED_APPS" in line and "+=" in line:
             plus_start_idx = i
-            paren_count = line.count('(') + line.count('[') - line.count(')') - line.count(']')
-            
+            paren_count = (
+                line.count("(") + line.count("[") - line.count(")") - line.count("]")
+            )
+
             if paren_count == 0:
                 plus_end_idx = i
                 break
             else:
                 # Find the closing paren/bracket
                 for j in range(i + 1, len(lines)):
-                    paren_count += lines[j].count('(') + lines[j].count('[')
-                    paren_count -= lines[j].count(')') + lines[j].count(']')
+                    paren_count += lines[j].count("(") + lines[j].count("[")
+                    paren_count -= lines[j].count(")") + lines[j].count("]")
                     if paren_count == 0:
                         plus_end_idx = j
                         break
             break
-    
+
     if plus_start_idx is not None and plus_end_idx is not None:
         # Insert missing apps before the closing parenthesis
         new_lines = lines[:plus_end_idx]
         for app in sorted(missing_apps):
             new_lines.append(f'    "{app}",')
         new_lines.extend(lines[plus_end_idx:])
-        
+
         # Write back to file
-        with open(settings_path, 'w') as f:
-            f.write('\n'.join(new_lines))
-        
-        print(f"Added {len(missing_apps)} apps to INSTALLED_APPS += section in {settings_path}")
+        with open(settings_path, "w") as f:
+            f.write("\n".join(new_lines))
+
+        print(
+            f"Added {len(missing_apps)} apps to INSTALLED_APPS += section in {settings_path}"
+        )
     else:
         print("Warning: Could not find INSTALLED_APPS += section to add missing apps")
 
@@ -249,67 +270,69 @@ def update_pyproject_dependencies(pyproject_path, package_name, optional_deps_ke
     if not os.path.exists(pyproject_path):
         print(f"Error: pyproject.toml not found at {pyproject_path}")
         return
-    
+
     try:
-        with open(pyproject_path, 'r') as f:
+        with open(pyproject_path, "r") as f:
             content = f.read()
-        
+
         # Find the dependencies section
-        deps_match = re.search(r'dependencies\s*=\s*\[(.*?)\]', content, re.DOTALL)
+        deps_match = re.search(r"dependencies\s*=\s*\[(.*?)\]", content, re.DOTALL)
         if not deps_match:
             print("Error: Could not find dependencies section in pyproject.toml")
             return
-        
+
         current_deps_text = deps_match.group(1)
-        
+
         # Create dependency string
         if optional_deps_keys:
             # Use the first optional dependency key
             dep_string = f"{package_name}[{optional_deps_keys[0]}]"
         else:
             dep_string = package_name
-        
+
         # Check if already in dependencies
         if dep_string in current_deps_text or package_name in current_deps_text:
             print(f"{dep_string} already in dependencies")
             return
-        
+
         # Parse existing dependencies to properly format
         if current_deps_text.strip():
             # Split into lines and clean up
-            lines = current_deps_text.split('\n')
+            lines = current_deps_text.split("\n")
             existing_deps = []
-            
+
             for line in lines:
                 line = line.strip()
-                if line and not line.startswith('#'):
+                if line and not line.startswith("#"):
                     # Remove trailing comma and quotes, extract dependency name
-                    dep_line = line.rstrip(',').strip()
+                    dep_line = line.rstrip(",").strip()
                     if dep_line.startswith('"') and dep_line.endswith('"'):
                         existing_deps.append(dep_line)
                     elif dep_line.startswith("'") and dep_line.endswith("'"):
                         existing_deps.append(dep_line)
-                    elif dep_line and not dep_line.startswith('#'):
+                    elif dep_line and not dep_line.startswith("#"):
                         # Add quotes if missing
                         existing_deps.append(f'"{dep_line}"')
-            
+
             # Add the new dependency
             existing_deps.append(f'"{dep_string}"')
-            
+
             # Format with proper indentation and commas
-            new_deps_text = '\n    ' + ',\n    '.join(existing_deps) + '\n'
+            new_deps_text = "\n    " + ",\n    ".join(existing_deps) + "\n"
         else:
             # No existing dependencies
             new_deps_text = f'\n    "{dep_string}"\n'
-        
+
         new_dependencies = f"dependencies = [{new_deps_text}]"
-        new_content = re.sub(r'dependencies\s*=\s*\[.*?\]', new_dependencies, content, flags=re.DOTALL)
-        
-        with open(pyproject_path, 'w') as f:
+        new_content = re.sub(
+            r"dependencies\s*=\s*\[.*?\]", new_dependencies, content, flags=re.DOTALL
+        )
+
+        with open(pyproject_path, "w") as f:
             f.write(new_content)
-        
+
         print(f"Added {dep_string} to dependencies in {pyproject_path}")
-    
+
     except Exception as e:
         print(f"Error updating pyproject.toml: {e}")
 
@@ -319,81 +342,88 @@ def update_urls_py(urls_path, package_name):
     if not os.path.exists(urls_path):
         print(f"Error: urls.py not found at {urls_path}")
         return
-    
-    with open(urls_path, 'r') as f:
+
+    with open(urls_path, "r") as f:
         content = f.read()
-    
+
     # Check if the URL pattern already exists
     url_pattern = f"urlpatterns.append(path('', include('{package_name}.urls')))"
     if url_pattern in content:
         print(f"URL pattern for {package_name} already exists in urls.py")
         return
-    
+
     # Find the line with arches.urls and add after it
     arches_pattern = r"urlpatterns\.append\(path\('', include\('arches\.urls'\)\)\)"
     if re.search(arches_pattern, content):
         new_content = re.sub(
             arches_pattern,
             f"urlpatterns.append(path('', include('arches.urls')))\n{url_pattern}",
-            content
+            content,
         )
-        
-        with open(urls_path, 'w') as f:
+
+        with open(urls_path, "w") as f:
             f.write(new_content)
-        
+
         print(f"Added URL pattern for {package_name} to {urls_path}")
     else:
         print("Could not find arches.urls pattern in urls.py")
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Install an Arches app from a GitHub repository')
-    parser.add_argument('url', help='GitHub repository URL')
-    parser.add_argument('--branch', '-b', default=None, help='Git branch to clone')
-    parser.add_argument('--project-root', default='.', help='Project root directory')
-    
+    parser = argparse.ArgumentParser(
+        description="Install an Arches app from a GitHub repository"
+    )
+    parser.add_argument("url", help="GitHub repository URL")
+    parser.add_argument("--branch", "-b", default=None, help="Git branch to clone")
+    parser.add_argument("--project-root", default=".", help="Project root directory")
+
     args = parser.parse_args()
-    
+
     # Determine project structure
     project_root = os.path.abspath(args.project_root)
-    apps_dir = os.path.join(os.path.dirname(project_root), 'arches_apps')
-    
+    apps_dir = os.path.join(os.path.dirname(project_root), "arches_apps")
+
     # Find the Arches project directory (contains __init__.py)
-    project_dirs = [d for d in os.listdir(project_root) 
-                   if os.path.isdir(os.path.join(project_root, d)) and 
-                   os.path.exists(os.path.join(project_root, d, '__init__.py'))]
-    
+    project_dirs = [
+        d
+        for d in os.listdir(project_root)
+        if os.path.isdir(os.path.join(project_root, d))
+        and os.path.exists(os.path.join(project_root, d, "__init__.py"))
+    ]
+
     if not project_dirs:
-        print("Error: Could not find Arches project directory (no directory with __init__.py found)")
+        print(
+            "Error: Could not find Arches project directory (no directory with __init__.py found)"
+        )
         sys.exit(1)
-    
+
     arches_project = project_dirs[0]
-    
+
     # Extract repository name
     repo_name = extract_repo_name(args.url)
     repo_dir = os.path.join(apps_dir, repo_name)
-    
+
     # Create apps directory
     create_apps_dir(apps_dir)
-    
+
     # Clone repository
     clone_repository(args.url, repo_dir, args.branch)
-    
+
     # Parse pyproject.toml
     package_name, optional_deps_keys = parse_pyproject_toml(repo_dir)
-    
+
     # Update project files
-    settings_path = os.path.join(project_root, arches_project, 'settings.py')
-    cloned_settings_path = os.path.join(repo_dir, package_name, 'settings.py')
-    pyproject_path = os.path.join(project_root, 'pyproject.toml')
-    urls_path = os.path.join(project_root, arches_project, 'urls.py')
-    
+    settings_path = os.path.join(project_root, arches_project, "settings.py")
+    cloned_settings_path = os.path.join(repo_dir, package_name, "settings.py")
+    pyproject_path = os.path.join(project_root, "pyproject.toml")
+    urls_path = os.path.join(project_root, arches_project, "urls.py")
+
     update_installed_apps(settings_path, cloned_settings_path, package_name)
     update_pyproject_dependencies(pyproject_path, package_name, optional_deps_keys)
     update_urls_py(urls_path, package_name)
-    
+
     print(f"Successfully installed {package_name} from {args.url}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/project.yml
+++ b/project.yml
@@ -46,7 +46,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ghcr.io/flaxandteal/arches_${{ env.ARCHES_PROJECT }}
+          images: ghcr.io/${{ github.repository }}
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v5
@@ -104,7 +104,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ghcr.io/flaxandteal/arches_${{ env.ARCHES_PROJECT }}_static
+          images: ghcr.io/${{ github.repository }}_static
       - name: Build and push Docker image
         id: buildx
         uses: docker/build-push-action@v2
@@ -228,7 +228,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
         with:
-          images: ghcr.io/flaxandteal/arches_${{ env.ARCHES_PROJECT }}_static_py
+          images: ghcr.io/${{ github.repository }}_static_py
       - name: Set up Docker Context for Buildx
         id: buildx-context
         run: |

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,8 @@ env:
 jobs:
   Build-Arches:
     runs-on: [self-hosted]
+    permissions:
+      packages: write
     outputs:
       image: ${{ steps.extract_image_name.outputs.image_name }}
     steps:
@@ -67,6 +69,8 @@ jobs:
   Build-Arches-Static:
     runs-on: [self-hosted]
     needs: [Build-Arches]
+    permissions:
+      packages: write
     outputs:
       image: ${{ steps.extract_image_name.outputs.image_name }}
 
@@ -206,6 +210,8 @@ jobs:
   Build-Arches-Final:
     needs: [Build-Arches-Static, Build-Arches]
     runs-on: [self-hosted]
+    permissions:
+      packages: write
     outputs:
       image: ${{ steps.extract_image_name.outputs.image_name }}
     steps:

--- a/project.yml
+++ b/project.yml
@@ -292,12 +292,12 @@ jobs:
           install: false
           wait-on: 'http://arches:8000'
           wait-on-timeout: 6000
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: cypress-screenshots
           path: cypress/screenshots
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: cypress-videos

--- a/project.yml
+++ b/project.yml
@@ -104,8 +104,26 @@ jobs:
           buildkitd-flags: '--allow-insecure-entitlement network.host'
           driver-opts: |
               network=host
-      - name: Build and push Docker image
-        run: docker run --rm --network host willwill/wait-for-it -h localhost -p 8000 -t 0
+      - name: Wait for Arches service
+        run: |
+          CONTAINER_ID=$(docker ps --filter "ancestor=${{ needs['Build-Arches'].outputs.image }}" --format '{{.ID}}' | head -1)
+          echo "Arches container ID: $CONTAINER_ID"
+          for i in $(seq 1 120); do
+            if curl -sf http://localhost:8000/templates/views/components/language-switcher.htm > /dev/null 2>&1; then
+              echo "Arches is ready after $((i * 10)) seconds"
+              exit 0
+            fi
+            if [ $((i % 6)) -eq 0 ]; then
+              echo "=== Arches container logs (attempt $i/120, $((i * 10))s elapsed) ==="
+              docker logs --tail 30 "$CONTAINER_ID" 2>&1 || true
+              echo "=== End of logs ==="
+            fi
+            sleep 10
+          done
+          echo "=== FINAL: Full arches container logs ==="
+          docker logs "$CONTAINER_ID" 2>&1 || true
+          echo "Arches service did not become ready within 20 minutes"
+          exit 1
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
@@ -204,11 +222,6 @@ jobs:
           TZ: "PST"
         ports:
           - '8000:8000'
-        options: >-
-          --health-cmd "curl --fail http://localhost:8000/templates/views/components/language-switcher.htm || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 1000
   Build-Arches-Final:
     needs: [Build-Arches-Static, Build-Arches]
     runs-on: [self-hosted]

--- a/project.yml
+++ b/project.yml
@@ -2,8 +2,8 @@ name: Build Arches project
 run-name: Build Arches project
 on: [push]
 env:
-  ARCHES_BASE: ghcr.io/flaxandteal/arches-base:docker-8.1
-  ARCHES_PROJECT: quartz
+  ARCHES_BASE: __ARCHESBASE__
+  ARCHES_PROJECT: __ARCHESPROJECT__
 jobs:
   Build-Arches:
     runs-on: [self-hosted]

--- a/rabbitmq.conf
+++ b/rabbitmq.conf
@@ -1,0 +1,1 @@
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/settings_docker.py
+++ b/settings_docker.py
@@ -1,16 +1,27 @@
 import os
 from arches.settings import ELASTICSEARCH_HOSTS, DATABASES
 from arches.settings_docker import *
-ALLOWED_HOSTS = ['localhost', '*'] # get_env_variable("DOMAIN_NAMES").split()
+
+ALLOWED_HOSTS = ["localhost", "*"]  # get_env_variable("DOMAIN_NAMES").split()
 
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {"console": {"format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",},},
-    "handlers": {
-        "console": {"level": "WARNING", "class": "logging.StreamHandler", "formatter": "console"},
+    "formatters": {
+        "console": {
+            "format": "%(asctime)s %(name)-12s %(levelname)-8s %(message)s",
+        },
     },
-    "loggers": {"arches": {"handlers": ["console"], "level": "WARNING", "propagate": True}},
+    "handlers": {
+        "console": {
+            "level": "WARNING",
+            "class": "logging.StreamHandler",
+            "formatter": "console",
+        },
+    },
+    "loggers": {
+        "arches": {"handlers": ["console"], "level": "WARNING", "propagate": True}
+    },
 }
 
 MOBILE_OAUTH_CLIENT_ID = os.getenv("MOBILE_OAUTH_CLIENT_ID")
@@ -22,15 +33,24 @@ COMPRESS_ENABLED = os.getenv("COMPRESS_ENABLED")
 COMPRESS_ENABLED = COMPRESS_ENABLED and COMPRESS_ENABLED.lower() == "true"
 
 # Cover both forms, the first being deprecated
-ARCHES_NAMESPACE_FOR_DATA_EXPORT = os.getenv("ARCHES_NAMESPACE_FOR_DATA_EXPORT", "http://arches:8000/")
-PUBLIC_SERVER_ADDRESS = os.getenv("PUBLIC_SERVER_ADDRESS", ARCHES_NAMESPACE_FOR_DATA_EXPORT)
+ARCHES_NAMESPACE_FOR_DATA_EXPORT = os.getenv(
+    "ARCHES_NAMESPACE_FOR_DATA_EXPORT", "http://arches:8000/"
+)
+PUBLIC_SERVER_ADDRESS = os.getenv(
+    "PUBLIC_SERVER_ADDRESS", ARCHES_NAMESPACE_FOR_DATA_EXPORT
+)
 
-CSRF_TRUSTED_ORIGINS = [f"https://{domain}" for domain in os.getenv("DOMAIN_NAMES", "").split()]
-CELERY_BROKER_URL = os.getenv("CELERY_BROKER_URL", "amqp://{}:{}@{}".format(
-    os.getenv("RABBITMQ_USER"),
-    os.getenv("RABBITMQ_PASS"),
-    os.getenv("RABBITMQ_HOST", "rabbitmq")
-))  # RabbitMQ --> "amqp://guest:guest@localhost",  Redis --> "redis://localhost:6379/0"
+CSRF_TRUSTED_ORIGINS = [
+    f"https://{domain}" for domain in os.getenv("DOMAIN_NAMES", "").split()
+]
+CELERY_BROKER_URL = os.getenv(
+    "CELERY_BROKER_URL",
+    "amqp://{}:{}@{}".format(
+        os.getenv("RABBITMQ_USER"),
+        os.getenv("RABBITMQ_PASS"),
+        os.getenv("RABBITMQ_HOST", "rabbitmq"),
+    ),
+)  # RabbitMQ --> "amqp://guest:guest@localhost",  Redis --> "redis://localhost:6379/0"
 RABBITMQ_USER = os.getenv("RABBITMQ_USER")
 RABBITMQ_PASS = os.getenv("RABBITMQ_PASS")
 RABBITMQ_HOST = os.getenv("RABBITMQ_HOST", "rabbitmq")

--- a/settings_docker.py
+++ b/settings_docker.py
@@ -59,3 +59,15 @@ CASBIN_RELOAD_QUEUE = os.getenv("CASBIN_RELOAD_QUEUE", "reloadQueue")
 for host in ELASTICSEARCH_HOSTS:
     host["scheme"] = "http"
     host["port"] = int(host["port"])
+
+LOGGING["loggers"]["django_saml2_auth"] = {
+    "handlers": ["console"],
+    "level": "DEBUG",
+    "propagate": True,
+}
+
+import logging
+
+logging.getLogger(__name__).warning(
+    "SAML2_METADATA_URL = %s", os.getenv("SAML2_METADATA_URL", "NOT SET")
+)


### PR DESCRIPTION
 The toolkit previously assumed the build context was the parent of
  the Arches project directory (so paths were prefixed with
  ${ARCHES_PROJECT}/). The coral-arches v8 layout runs the build from
  the project root itself, which broke COPY paths and compose mounts.

Quick fix for now, will align with the current arches 8.1 toolkit 